### PR TITLE
Add pt-BR translation

### DIFF
--- a/pt-BR/Changelog.plist
+++ b/pt-BR/Changelog.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>2.2.0</key>
+	<array>
+		<dict>
+			<key>Title</key>
+			<string>Melhoria no ajuste de saldo</string>
+			<key>Description</key>
+			<string>Quando você modifica manualmente o saldo da sua conta, agora uma transação é criada automaticamente, mantendo seu histórico preciso e intacto.</string>
+			<key>IconName</key>
+			<string>building.columns</string>
+			<key>IconColor</key>
+			<string>#00a38b</string>
+		</dict>
+		<dict>
+			<key>Title</key>
+			<string>Personalização de ícones</string>
+			<key>Description</key>
+			<string>Agora você pode usar suas próprias imagens como ícones, seja o logotipo do seu banco para contas ou fotos pessoais para categorias.</string>
+			<key>IconName</key>
+			<string>photo.on.rectangle.angled</string>
+			<key>IconColor</key>
+			<string>#007aff</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/pt-BR/InfoPlist.strings
+++ b/pt-BR/InfoPlist.strings
@@ -1,0 +1,20 @@
+/*
+  InfoPlist.strings
+  BudgetFlow
+
+  Created by Fabian Hasse on 23.07.20.
+  Copyright © 2020 Fabian Hasse. All rights reserved.
+*/
+
+"CFBundleName" = "Budget Flow";
+"CFBundleDisplayName" = "Budget Flow";
+
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "O acesso à sua localização é utilizado para adicionar automaticamente a sua localização atual às transações.";
+"NSLocationUsageDescription" = "O acesso à sua localização é utilizado para adicionar automaticamente a sua localização atual às transações.";
+"NSLocationWhenInUseUsageDescription" = "O acesso à sua localização é utilizado para adicionar automaticamente a sua localização atual às transações.";
+"NSCameraUsageDescription" = "O acesso à sua câmera é usado para adicionar fotos às transações.";
+"NSPhotoLibraryUsageDescription" = "O acesso à sua biblioteca de fotos é usado para salvar automaticamente as fotos tiradas.";
+"NSPhotoLibraryAddUsageDescription" = "O acesso à sua biblioteca de fotos é usado para salvar automaticamente as fotos tiradas.";
+"NSFaceIDUsageDescription" = "O acesso ao Face ID é necessário para que você possa desbloquear o app sem inserir uma senha.";
+"NSTouchIDUsageDescription" = "O acesso ao Touch ID é necessário para que possa desbloquear a aplicação sem introduzir um código de acesso.";
+"NSContactsUsageDescription" = "O acesso aos seus contatos é usado para exibir nomes e fotos de pessoas com quem você compartilhou seu livro de orçamento.";

--- a/pt-BR/Localizable.strings
+++ b/pt-BR/Localizable.strings
@@ -1,0 +1,2014 @@
+/*
+  Localizable.strings
+  BudgetFlow
+
+  Created by Fabian Hasse on 19.05.20.
+  Copyright © 2020 Fabian Hasse. All rights reserved.
+*/
+
+/* MARK: - General */
+"app_name" = "Budget Flow";
+
+"feedback_quick_action_title" = "Feedback";
+"feedback_quick_action_subtitle" = "Clique aqui para dar a sua opinião sobre o aplicativo";
+"income_quick_action_title" = "Nova receita";
+"expense_quick_action_title" = "Nova despesa";
+"transfer_quick_action_title" = "Nova transferência";
+"recurring_quick_action_title" = "Recorrente";
+
+
+/* MARK: - Miscellaneous */
+"face_id" = "Face ID";
+"touch_id" = "Touch ID";
+"required" = "Obrigatório";
+"optional" = "Opcional";
+"uncategorized" = "Sem categoria";
+"before" = "antes";
+"account_reconcilation" = "Reconciliação de conta";
+
+
+/* MARK: - Enums */
+"account_type_cash" = "Dinheiro";
+"account_type_payment" = "Conta de pagamento";
+"account_type_savings" = "Conta poupança";
+"account_type_credit_card" = "Cartão de crédito";
+"account_type_investment" = "Investimento";
+"account_type_precaution" = "Reserva de emergência";
+"account_type_liability" = "Passivo";
+"account_type_business" = "Conta empresarial";
+
+"account_type_payment_plural" = "Contas de pagamento";
+"account_type_savings_plural" = "Contas de poupança";
+"account_type_credit_card_plural" = "Cartões de crédito";
+"account_type_investment_plural" = "Investimentos";
+"account_type_precaution_plural" = "Precaução";
+"account_type_liability_plural" = "Passivos";
+"account_type_business_plural" = "Contas empresariais";
+
+"transaction_type_income" = "Receita";
+"transaction_type_expense" = "Despesa";
+"transaction_type_transfer" = "Transferência";
+
+"transaction_type_income_plural" = "Receitas";
+"transaction_type_expense_plural" = "Despesas";
+"transaction_type_transfer_plural" = "Transferências";
+
+"payment_status" = "Status";
+"payment_status_completed" = "Concluído";
+"payment_status_pending" = "Pendente";
+
+"attachment_type_image" = "Foto";
+"attachment_type_image_plural" = "Fotos";
+"attachment_type_document" = "Documento";
+"attachment_type_document_plural" = "Documentos";
+
+"period_type_month" = "Mês";
+"period_type_year" = "Ano";
+"period_type_custom" = "Data";
+
+"sort_type_alphabetically" = "Alfabética";
+"sort_type_date" = "Data";
+"sort_type_amount" = "Valor";
+"sort_type_type" = "Tipo";
+
+"sort_option_ascending" = "Ascendente";
+"sort_option_descending" = "Descendente";
+
+"group_option_day" = "Dia";
+"group_option_month" = "Mês";
+"group_option_account" = "Conta";
+"group_option_category" = "Categoria";
+"group_option_category_group" = "Pasta";
+"group_option_type" = "Tipo";
+"group_option_payee" = "Beneficiário";
+"group_option_repetition_frequency" = "Intervalo";
+
+"date_repetition_frequency_never" = "Nunca";
+"date_repetition_frequency_daily" = "Diariamente";
+"date_repetition_frequency_weekly" = "Semanalmente";
+"date_repetition_frequency_everyTwoWeeks" = "A cada 2 semanas";
+"date_repetition_frequency_everyThreeWeeks" = "A cada 3 semanas";
+"date_repetition_frequency_everyFourWeeks" = "A cada 4 semanas";
+"date_repetition_frequency_monthly" = "Mensalmente";
+"date_repetition_frequency_everyTwoMonths" = "A cada 2 meses";
+"date_repetition_frequency_everyThreeMonths" = "Trimestralmente";
+"date_repetition_frequency_everySixMonths" = "Semestralmente";
+"date_repetition_frequency_yearly" = "Anualmente";
+"date_repetition_frequency_custom" = "Personalizado";
+
+"csv_transaction_type_automatic" = "Automático";
+"csv_transaction_type_income" = "Receita";
+"csv_transaction_type_expenses" = "Despesas";
+
+"passcode_type_four_digits" = "Senha numérica de 4 dígitos";
+"passcode_type_six_digits" = "Senha numérica de 6 dígitos";
+"passcode_type_custom_numeric" = "Senha numérica personalizada";
+"passcode_type_custom_alphanumeric" = "Senha alfanumérica personalizada";
+
+"auto_lock_time_type_immediately" = "Imediatamente";
+"auto_lock_time_type_after_one_minute" = "Após 1 minuto";
+"auto_lock_time_type_after_five_minutes" = "Após 5 minutos";
+"auto_lock_time_type_after_fifteen_minutes" = "Após 15 minutos";
+"auto_lock_time_type_after_one_hour" = "Após 1 hora";
+"auto_lock_time_type_after_four_hours" = "Após 4 horas";
+
+"widget_type_chart_stack" = "Gráficos";
+"widget_type_suggestions" = "Sugestões";
+"widget_type_distribution" = "Distribuição";
+"widget_type_balance" = "Saldo";
+"widget_type_savings_rate" = "Poupado";
+"widget_type_upcoming_transactions" = "Planejado";
+"widget_type_participants" = "Pessoas";
+"widget_type_budget" = "Orçamento";
+"widget_type_pending_transactions" = "Pendente";
+"widget_type_total_assets" = "Ativos";
+"widget_type_forecast" = "Previsão";
+
+"chart_type_bar" = "Gráfico de barras";
+"chart_type_pie" = "Gráfico de pizza";
+
+"category_chart_data_type_category" = "Categoria";
+"category_chart_data_type_category_group" = "Pasta";
+
+"product_type_individual" = "Individual";
+"product_type_family" = "Família";
+
+"subscription_period_day" = "Dia";
+"subscription_period_days" = "dias";
+"subscription_period_month" = "Mês";
+"subscription_period_months" = "Meses";
+"subscription_period_year" = "ano";
+"subscription_period_years" = "Anos";
+
+"overview_period_type_current_week" = "Esta semana";
+
+"quick_action_type_new_income" = "Nova receita";
+"quick_action_type_new_expense" = "Nova despesa";
+"quick_action_type_new_transfer" = "Nova transferência";
+"quick_action_type_new_recurring" = "Recorrente";
+
+"suggestion_type_add_income_transaction" = "Nova receita";
+"suggestion_type_add_expense_transaction" = "Nova despesa";
+
+"user_interface_style_system" = "Sistema";
+"user_interface_style_light" = "Claro";
+"user_interface_style_dark" = "Escuro";
+
+"transaction_title_type_category" = "Categoria";
+"transaction_title_type_payee" = "Beneficiário";
+"transaction_title_type_notes" = "Notas";
+
+"transaction_subtitle_type_none" = "Nenhum";
+"transaction_subtitle_type_category" = "Categoria";
+"transaction_subtitle_type_payee" = "Beneficiário";
+"transaction_subtitle_type_notes" = "Notas";
+
+
+/* MARK: - Custom Date Repetition */
+"frequency" = "Frequência";
+
+"every" = "a cada";
+"every_day" = "Todo";
+"every_week" = "Toda";
+"every_month" = "Todo";
+"every_year" = "Todo";
+"every_day_plural" = "Todos os";
+"every_week_plural" = "Todas as";
+"every_month_plural" = "Todos os";
+"every_year_plural" = "Todos os";
+
+
+"each" = "Cada";
+"on_the" = "No dia";
+"days_of_week" = "Dias da semana";
+"last_day" = "Último dia";
+
+"daily" = "Diário";
+"weekly" = "Semanal";
+"monthly" = "Mensal";
+"yearly" = "Anual";
+
+"first" = "1º";
+"second" = "2º";
+"third" = "3º";
+"fourth" = "4º";
+"fifth" = "5º";
+"last" = "Último";
+
+
+/* MARK: - Menu Bar */
+"accounts_menu_title" = "Contas";
+"show_accounts_menu_title" = "Mostrar todas as contas";
+"budgets_menu_title" = "Orçamentos";
+"show_budgets_menu_title" = "Mostrar todos os orçamentos";
+"transactions_menu_title" = "Transações";
+"show_all_transactions_menu_title" = "Mostrar todas as transações";
+"show_recurring_transactions_menu_title" = "Mostrar transações recorrentes";
+"show_upcoming_transactions_menu_title" = "Mostrar transações planejadas";
+
+
+/* MARK: - Sidebar Menu */
+"menu" = "Menu";
+"menu_accounts_section" = "Contas";
+"menu_categories_section" = "Categorias";
+"menu_selected_budget_book_title" = "Selecionado";
+
+
+/* MARK: - Tabs */
+"dashboard_tab" = "Visão Geral";
+"transactions_tab" = "Transações";
+"budgets_tab" = "Orçamentos";
+"settings_tab" = "Configurações";
+
+
+/* MARK: - Buttons */
+"add_button" = "Adicionar";
+"edit_button" = "Editar";
+"copy_button" = "Copiar";
+"edit_account_button" = "Editar conta";
+"edit_category_button" = "Editar categoria";
+"edit_payee_button" = "Editar beneficiário";
+"edit_tag_button" = "Editar tag";
+"edit_budget_button" = "Editar orçamento";
+"multi_selection_button" = "Seleção múltipla";
+"back_button" = "Voltar";
+"done_button" = "OK";
+"save_button" = "Salvar";
+"import_button" = "Importar";
+"unlock_button" = "Desbloquear";
+"cancel_button" = "Cancelar";
+"close_button" = "Fechar";
+"delete_button" = "Excluir";
+"end_repetition_button" = "Fim da repetição";
+"reset_button" = "Redefinir";
+"apply_button" = "Aplicar";
+"yes_button" = "Sim";
+"no_button" = "Não";
+"ok_button" = "OK";
+"faq_button" = "FAQ";
+"create_reminder_button" = "Criar lembrete";
+"remove_reminder_button" = "Remover lembrete";
+"do_not_show_again_button" = "Não mostrar novamente";
+"mark_as_paid_button" = "Marcar como pago";
+"mark_as_pending_button" = "Marcar como pendente";
+"show_contra_entry_button" = "Mostrar contrapartida";
+
+"save_changes_button" = "Salvar alterações";
+"discard_changes_button" = "Descartar alterações";
+
+"show_help_center_button" = "Central de Ajuda (🇬🇧)";
+"contact_developer_button" = "Contatar o desenvolvedor";
+
+"filter_button" = "Filtrar";
+"sort_button" = "Ordenar";
+"sort_categories_button" = "Ordenar categorias";
+"sort_category_groups_button" = "Ordenar pastas";
+"group_button" = "Agrupar";
+"configure_button" = "Configurar";
+
+"show_filter_button" = "Mostrar filtro";
+
+"show_amount_values_button" = "Mostrar valores";
+"hide_amount_values_button" = "Ocultar valores";
+
+"take_photo_button" = "Tirar foto";
+"add_photo_button" = "Selecionar fotos";
+"add_document_button" = "Selecionar documentos";
+"scan_receipt_button" = "Digitalizar recibo";
+
+"open_button" = "Abrir";
+"open_folder_button" = "Abrir pasta";
+"open_in_browser_button" = "Abrir no navegador";
+
+"show_more_button" = "Mostrar mais";
+"show_less_button" = "Mostrar menos";
+
+"add_category_button" = "Nova categoria";
+"add_category_group_button" = "Nova pasta";
+
+"add_income_transaction_button" = "Nova receita";
+"add_expense_transaction_button" = "Nova despesa";
+"add_transfer_transaction_button" = "Nova transferência";
+
+"manage_budget_books_button" = "Gerenciar Cadernos de Orçamento";
+"select_budget_book_button" = "Selecionar Caderno de Orçamento";
+"edit_budget_book_button" = "Editar Caderno de Orçamento";
+
+"continue_button" = "Continuar";
+"skip_button" = "Pular";
+"accept_button" = "Aceitar";
+"get_started_button" = "Começar";
+
+"show_transactions_button" = "Mostrar transações";
+"show_in_app_store_button" = "Mostrar na App Store";
+
+"learn_more" = "Saiba mais";
+
+
+/* MARK: - Share View */
+/* Titles */
+"share_title" = "Compartilhar";
+
+/* Alert Views */
+"alert_sync_shares_in_progress_title" = "Sincronizando...";
+"alert_sync_shares_in_progress_message" = "Seus Cadernos de Orçamento estão sincronizando com o iCloud para que você possa acessar o conteúdo compartilhado. Por favor, aguarde...";
+"alert_cloud_share_quota_exceeded_error_message" = "Não foi possível concluir o compartilhamento porque não há espaço suficiente no seu iCloud. Libere espaço e tente novamente.";
+"alert_cloud_share_unknown_error_message" = "Não foi possível concluir o compartilhamento porque ocorreu um erro. Provavelmente não há espaço suficiente disponível no seu iCloud. Libere espaço e tente novamente.";
+
+
+/* MARK: - Search View */
+/* Titles */
+"search_title" = "Pesquisar";
+"filter_title" = "Filtro";
+
+/* Sections */
+"search_text_section_title" = "Pesquisar texto";
+"search_suggestions_section_title" = "Sugestões";
+
+
+/* MARK: - Period Selection View */
+/* Titles */
+"period_selection_title" = "Período";
+"period_selection_current_year_title" = "Ano atual";
+"period_selection_current_month_title" = "Mês atual";
+
+/* Items */
+"from_title" = "De";
+"to_title" = "Até";
+
+
+/* MARK: - Dashboard View */
+/* Titles */
+"configure_title" = "Configurar";
+"balance_widget_income_title" = "Receitas";
+"balance_widget_expenses_title" = "Despesas";
+"savings_rate_widget_absolute_title" = "Total";
+"savings_rate_widget_percentual_title" = "Percentual";
+"budget_widget_planned_title" = "Planejado";
+"budget_widget_remaining_title" = "Disponível";
+"total_assets_widget_absolute_title" = "Total";
+"total_assets_widget_trend_title" = "Tendência";
+"forecast_widget_upcoming_title" = "Planejado";
+"forecast_widget_pending_title" = "Pendente";
+"forecast_widget_final_balance_title" = "Saldo final";
+"pie_chart_widget_transactions_title" = "Transações";
+"pie_chart_widget_categories_title" = "Categorias";
+
+/* Sections */
+"inactive_widgets_section_title" = "Mais widgets";
+
+/* Footer */
+"participants_widget_footer_title" = "Nota: O widget \"Pessoas\" só aparece para Cadernos de Orçamento compartilhados.";
+
+/* Messages */
+"no_widgets_title" = "Nenhum widget adicionado";
+"no_widgets_message" = "Clique no botão \"lápis\" para configurar a visualização.";
+"no_suggestions_title" = "Sem sugestões";
+"not_shared_title" = "Caderno de Orçamento não compartilhado";
+
+/* Widgets */
+"account_balances_widget_title" = "Saldos das contas";
+"balance_widget_title" = "Saldo";
+"total_income_widget_title" = "Receita total";
+"total_expenses_widget_title" = "Despesa total";
+"fixed_expenses_widget_title" = "Despesas fixas";
+"variable_expenses_widget_title" = "Despesas variáveis";
+
+"account_balances_distribution_widget_title" = "Saldos das contas";
+"balance_distribution_widget_title" = "Saldo";
+"total_income_distribution_widget_title" = "Receita total";
+"total_expenses_distribution_widget_title" = "Despesa total";
+"fixed_expenses_distribution_widget_title" = "Despesas fixas";
+"variable_expenses_distribution_widget_title" = "Despesas variáveis";
+
+
+/* MARK: - Transaction List View */
+/* Titles */
+"sum_title" = "Soma";
+"total_sum_title" = "Soma total";
+"recurring_transactions_title" = "Recorrentes";
+"upcoming_transactions_title" = "Planejadas";
+"reminded_transactions_title" = "Com lembrete";
+
+/* Info */
+"recurring_transactions_info_title" = "Descrição";
+"recurring_transactions_info_description" = "Crie transações recorrentes para que sejam automaticamente adicionadas ao aplicativo quando vencerem.";
+
+/* Sections */
+"account_filter_section_title" = "Conta";
+"category_filter_section_title" = "Categoria";
+"payee_filter_section_title" = "Beneficiário";
+"tag_filter_section_title" = "Tag";
+"user_filter_section_title" = "Pessoa";
+"payment_status_filter_section_title" = "Pagamento";
+"transaction_type_filter_section_title" = "Tipo";
+"date_range_filter_section_title" = "Período";
+"amount_range_filter_section_title" = "Valor";
+
+/* Messages */
+"no_transactions_title" = "Sem transações";
+"no_transactions_title_short" = "Nenhuma";
+"no_transactions_found_title" = "Nenhuma transação encontrada";
+"no_transactions_found_message" = "Clique no botão \"+\" para adicionar uma nova transação.";
+"no_transactions_found_button_title" = "Nova transação";
+"no_recurring_transactions_found_message" = "Clique no botão \"+\" para adicionar uma nova transação recorrente.";
+"no_upcoming_transactions_found_message" = "Clique no botão \"+\" para adicionar uma nova transação planejada.";
+"no_reminded_transactions_found_message" = "Clique no botão \"+\" para adicionar uma nova transação com um lembrete.";
+"transactions_search_placeholder_message" = "Pesquisar por nome de categoria, beneficiário, tag ou notas";
+
+/* Buttons */
+"show_analysis_button" = "Mostrar análise";
+"show_analysis_button_short" = "Análise";
+"show_forecast_button" = "Mostrar previsão";
+"show_forecast_button_short" = "Previsão";
+"show_upcoming_transactions_button" = "Planejadas";
+
+/* Alert Views */
+"alert_confirm_add_next_upcoming_transaction_title" = "Adicionar transação";
+"alert_confirm_add_next_upcoming_transaction_message" = "Tem certeza de que deseja adicionar esta transação planejada agora?";
+
+/* Miscellaneous */
+"payed_by_and_modified_at" = "Pago por %@\nÚltima modificação em %@";
+"modified_at" = "Última modificação em %@";
+"average_per_transaction" = "Média por transação";
+"average_per_day" = "Média por dia";
+"average_per_month" = "Média por mês";
+
+
+/* MARK: - Budget List View */
+/* Titles */
+"remaining_title" = "Disponível";
+"balanced_title" = "Equilibrado";
+"exceeded_title" = "Excedido";
+"user_has_no_budgets_title" = "Você não tem orçamentos.";
+"user_is_within_budget_title" = "Você está dentro do seu orçamento! 🎉";
+"user_was_within_budget_title" = "Você estava dentro do seu orçamento! 🎉";
+"user_is_not_within_budget_title" = "Você excedeu %d orçamento 😢";
+"user_is_not_within_budgets_title" = "Você excedeu %d orçamentos 😢";
+
+/* Messages */
+"no_budgets_title" = "Sem orçamentos";
+"no_budgets_found_title" = "Nenhum orçamento encontrado";
+"no_budgets_found_message" = "Clique no botão \"+\" para adicionar um novo orçamento.";
+"budgets_search_placeholder_message" = "Pesquisar pelo nome de um orçamento";
+"no_budgets_found_button_title" = "Novo orçamento";
+
+
+/* MARK: - Analysis View */
+/* Titles */
+"analysis_title" = "Análise";
+"trend_widget_average_title" = "Média";
+"trend_widget_current_year_title" = "Este ano";
+"trend_widget_current_month_title" = "Este mês";
+
+/* Messages */
+"trend_widget_received_more_message" = "Você está recebendo mais do que o normal.";
+"trend_widget_received_less_message" = "Você está recebendo menos que o normal.";
+"trend_widget_received_same_message" = "Você está recebendo o mesmo de sempre.";
+"trend_widget_has_received_more_message" = "Você recebeu mais do que o normal.";
+"trend_widget_has_received_less_message" = "Você recebeu menos do que o normal.";
+"trend_widget_has_received_same_message" = "Você recebeu o mesmo de sempre.";
+
+"trend_widget_spent_more_message" = "Você está gastando mais do que o normal.";
+"trend_widget_spent_less_message" = "Você está gastando menos do que o normal.";
+"trend_widget_spent_same_message" = "Você está gastando o mesmo de sempre.";
+"trend_widget_has_spent_more_message" = "Você gastou mais do que o normal.";
+"trend_widget_has_spent_less_message" = "Você gastou menos do que o normal.";
+"trend_widget_has_spent_same_message" = "Você gastou o mesmo de sempre.";
+
+"total_balance_widget_current_balance_message" = "Seu saldo é %@.";
+"total_balance_widget_previous_balance_message" = "Seu saldo era %@.";
+
+"savings_rate_widget_current_savings_rate_message" = "Sua taxa de poupança é de %@%%.";
+"savings_rate_widget_previous_savings_rate_message" = "Sua taxa de poupança foi de %@%%.";
+
+/* Widgets */
+"trend_widget_title" = "Tendência";
+"total_balance_widget_title" = "Saldo";
+"savings_rate_widget_title" = "Taxa de poupança";
+
+
+/* MARK: - Account Forecast View */
+/* Titles */
+"account_forecast_title" = "Previsão";
+"account_balance_title" = "Saldo";
+"not_enough_data_title" = "Dados insuficientes";
+
+
+/* MARK: - Settings View */
+/* Titles */
+"no_budget_book_title" = "Sem Caderno de Orçamento";
+
+/* Messages */
+"share_app_message" = "\"%@ - Gerenciador de Despesas\"\n\nFaça o download agora gratuitamente:";
+
+/* Sections */
+"general_setting_section_title" = "Geral";
+"upgrade_setting_section_title" = "Versão Completa";
+"support_setting_section_title" = "Suporte";
+"legal_setting_section_title" = "Jurídico";
+"data_setting_section_title" = "Dados";
+"miscellaneous_setting_section_title" = "Diversos";
+
+/* Footer */
+"upgrade_setting_footer_title" = "Obrigado por usar a versão completa!";
+"support_setting_footer_title" = "Alguma dúvida ou ideia? Escreva uma mensagem ou uma avaliação positiva na App Store! Seu feedback é muito motivador e ajuda a melhorar o aplicativo.";
+
+/* Buttons */
+"share_budgetbook_button" = "Compartilhar Caderno de Orçamento";
+"show_participants_button" = "Mostrar participantes";
+"cloud_not_available_button" = "iCloud não disponível";
+"upgrade_show_all_features_button" = "Todos os recursos";
+"reset_app_button" = "Redefinir aplicativo";
+
+/* General Settings */
+"accounts_setting_title" = "Gerenciar contas";
+"categories_setting_title" = "Gerenciar categorias";
+"payees_setting_title" = "Gerenciar beneficiários";
+"tags_setting_title" = "Gerenciar tags";
+"reminders_setting_title" = "Lembretes";
+
+/* Upgrade Settings */
+"upgrade_setting_title" = "Desbloquear versão completa 🚀";
+"upgrade_setting_description" = "Desbloqueie a versão completa agora e aproveite os recursos adicionais!";
+
+/* Support Settings */
+"share_app_setting_title" = "Indicar para amigos";
+"translate_app_setting_title" = "Ajudar na tradução";
+"help_center_setting_title" = "Central de Ajuda (🇬🇧)";
+"feature_roadmap_setting_title" = "Sugerir recurso";
+"rate_app_setting_title" = "Avaliar o aplicativo";
+
+/* Legal Settings */
+"imprint_setting" = "Expediente";
+"privacy_setting" = "Política de Privacidade";
+"terms_of_use_setting" = "Termos de Uso";
+"acknowledgements_setting" = "Agradecimentos";
+"licenses_setting" = "Licenças";
+
+"acknowledgements_setting_info_title" = "Descrição";
+"acknowledgements_setting_info_description" = "Abaixo está uma lista de pessoas que ajudaram com o aplicativo de alguma forma.";
+"translation_acknowledgement" = "Tradução (%@)";
+"licenses_setting_info_title" = "Descrição";
+"licenses_setting_info_description" = "Abaixo está uma lista de todas as licenças de terceiros usadas pelo aplicativo.";
+
+/* Data Settings */
+"sync_and_data_setting" = "Sincronização de dados";
+"sync_and_data_setting_short" = "Sincronização";
+"recurring_transactions_setting" = "Transações recorrentes";
+
+/* Miscellaneous Settings */
+"new_features_setting" = "Novos recursos";
+"testflight_beta_setting" = "TestFlight beta";
+"apple_pay_setting" = "Integração com Apple Pay";
+"appearance_setting" = "Aparência";
+"advanced_setting" = "Configurações avançadas";
+
+/* Contact Developer */
+"mail_subject_type_contact" = "Contato";
+"mail_subject_type_support" = "Suporte";
+"mail_subject_type_feedback" = "Feedback";
+"mail_subject_type_translate" = "Traduzir";
+"mail_subject_type_discount" = "Desconto";
+
+"alert_contact_developer_title" = "Sobre o que é sua solicitação?";
+"alert_contact_developer_feature_request" = "💡 Sugerir recurso";
+"alert_contact_developer_bug_report" = "🐞 Relatar bug";
+"alert_contact_developer_other" = "📬 Outro (e-mail)";
+
+"contact_developer_mail_subject" = "%@: %@%@";
+"contact_developer_mail_subject_full_version" = " (versão completa)";
+"contact_developer_mail_message" = "
+</br>
+</br>
+</br>
+</br>
+</br>
+</br>
+</br>
+<b>Support Information:</b>
+</br>
+<u>General:</u></br>
+- Device: %@</br>
+- iOS version: %@</br>
+- Language: %@</br>
+- Currency: %@</br>
+- Time zone: %@</br>
+</br>
+<u>App Specific:</u></br>
+- App version: %@</br>
+- Build: %@</br>
+</br>
+<u>In-App Purchases:</u></br>
+- User ID: %@</br>
+- Active: %@</br>
+- Purchases: %@";
+"contact_developer_mail_no_purchases" = "None";
+
+/* Appearance Settings */
+"appearance_setting_info_title" = "Descrição";
+"appearance_setting_info_description" = "Personalize o aplicativo ao seu gosto, alterando a aparência ou a cor de destaque do aplicativo.";
+"appearance_ui_style_setting_section_title" = "Tema";
+"appearance_ui_style_setting_footer_title" = "Altera a aparência do aplicativo.";
+"appearance_accent_color_setting_section_title" = "Cor de destaque";
+"appearance_accent_color_setting_footer_title" = "Altera a cor dos botões e outros controles dentro do aplicativo.";
+"appearance_app_icon_setting_section_title" = "Ícone do aplicativo";
+
+/* Sync & Data Settings */
+"sync_and_data_setting_info_title" = "Descrição";
+"sync_and_data_setting_info_description" = "Obtenha uma visão geral do status de sincronização atual e importe ou exporte dados usando um arquivo CSV.";
+
+"sync_and_data_cloud_setting_section_title" = "iCloud";
+"sync_and_data_cloud_setting_footer_title" = "Indica se a sincronização com o iCloud foi bem-sucedida ou se ocorreu um erro.";
+"sync_and_data_setting_cloud_sync_status_title" = "Status de sincronização";
+"backup_setting_section_title" = "Backups";
+"backup_setting_footer_title" = "Gerencie seus backups e configurações de backup.";
+"backup_setting_manage_backups_title" = "Gerenciar";
+"sync_and_data_csv_setting_section_title" = "Dados CSV";
+"sync_and_data_csv_setting_footer_title" = "Importe ou exporte suas transações usando um arquivo CSV.";
+"sync_and_data_setting_csv_import_title" = "Importar";
+"sync_and_data_setting_csv_export_title" = "Exportar";
+"sync_and_data_setting_get_csv_template_title" = "Baixar modelo";
+
+"clear_cache_button" = "Limpar cache";
+"cache_setting_footer_title" = "Nota: limpar o cache exclui todos os arquivos do diretório de documentos do aplicativo (incluindo backups).";
+
+"alert_csv_import_successful_title" = "Importação bem-sucedida 🎉";
+"alert_csv_import_successful_message" = "No total, %d de %d transações foram importadas.%@";
+"alert_csv_import_skipped_message" = "Assim, %d transações foram ignoradas.";
+"alert_csv_import_error_message" = "Falha ao importar %d de %d transações com êxito.\n\n%@";
+"alert_csv_import_error_reason_field_message" = "Verifique os seguintes campos no seu arquivo CSV: %@.";
+
+"alert_csv_export_successful_title" = "Exportação bem-sucedida 🎉";
+"alert_csv_export_successful_message" = "Seus dados foram exportados com êxito para \"%@\".";
+
+/* Cloud Settings */
+"cloud_setting_info_title" = "Descrição";
+"cloud_setting_info_description" = "A visualização a seguir fornece uma visão geral mais detalhada do status atual de sincronização do iCloud e ajuda na solução de problemas.";
+
+"cloud_setting_network_status_title" = "Rede";
+"cloud_setting_network_status_success_value" = "Conexão com a Internet disponível";
+"cloud_setting_network_status_error_value" = "Sem conexão com a Internet";
+"cloud_setting_account_status_title" = "Conta do iCloud";
+"cloud_setting_account_status_success_value" = "Conectado ao iCloud";
+"cloud_setting_account_status_error_value" = "Não conectado ao iCloud";
+"cloud_setting_upload_status_title" = "Último upload";
+"cloud_setting_download_status_title" = "Último download";
+"cloud_setting_number_of_transactions_title" = "Transações";
+"cloud_setting_number_of_transactions_value" = "No dispositivo: %d\nNo iCloud: %d";
+"cloud_setting_number_of_transactions_in_progress_title" = "Aguarde...";
+"cloud_setting_number_of_transactions_error_title" = "Erro";
+
+/* Backup Settings */
+"backup_setting_info_title" = "Descrição";
+"backup_setting_info_description" = "Quando ativado, o Budget Flow faz backup regularmente de seus dados para que você possa restaurar o aplicativo para um estado anterior a qualquer momento.";
+
+"backup_general_setting_section_title" = "Geral";
+"backup_recent_backups_setting_section_title" = "Backups recentes";
+"backup_setting_use_automatic_backups_title" = "Backup automático";
+"backup_setting_create_backup_title" = "Criar backup";
+
+"alert_restore_backup_title" = "Restaurar este backup?";
+"alert_restore_backup_message" = "A restauração de backups é atualmente um recurso experimental. Ele apagará seus dados atuais e os substituirá pelo backup selecionado.\n\nDepois disso, o aplicativo será fechado automaticamente.\n\nAviso: Este processo não pode ser desfeito!";
+"alert_restore_backup_button" = "Restaurar backup";
+
+/* Advanced Settings */
+"advanced_setting_info_title" = "Descrição";
+"advanced_setting_info_description" = "Faça mais configurações para personalizar o aplicativo.";
+
+"advanced_security_setting_section_title" = "Segurança";
+"advanced_view_setting_section_title" = "Exibição";
+"advanced_sidebar_setting_section_title" = "Barra Lateral";
+"advanced_transaction_setting_section_title" = "Transações";
+"advanced_other_setting_section_title" = "Outros";
+
+"advanced_setting_use_passcode_title" = "Usar senha";
+"advanced_setting_use_title" = "Usar %@";
+"advanced_setting_auto_lock_title" = "Pedir senha";
+
+"advanced_setting_chart_type_title" = "Tipo de gráfico";
+"advanced_setting_show_frequency_used_items_title" = "Mostrar categorias e tags frequentes";
+"advanced_setting_show_frequently_used_items_description" = "Mostrar categorias e tags usadas com frequência na lista de seleção ao criar e editar transações.";
+"advanced_setting_show_notes_in_title_title" = "Mostrar notas em vez de categoria";
+"advanced_setting_show_notes_in_title_description" = "Mostrar o conteúdo das notas em vez do nome da categoria para transações.";
+"advanced_setting_start_day_of_month_title" = "Dia de início do mês";
+"advanced_setting_start_day_of_month_description" = "Especifique o dia de início de cada mês para que os relatórios, transações e orçamentos sejam calculados corretamente.";
+"advanced_setting_configure_transaction_title_title" = "Título da transação";
+"advanced_setting_configure_transaction_subtitle_title" = "Subtítulo da transação";
+
+"advanced_setting_configure_transation_title_info_title" = "Descrição";
+"advanced_setting_configure_transation_title_info_description" = "Configure a ordem do título da transação. Por padrão, o nome da categoria será apresentado primeiro. Se faltar a categoria, o nome do destinatário será utilizado. Se não for atribuído nenhum destinatário, as notas serão apresentadas.";
+
+"advanced_setting_show_accounts_in_sidebar_title" = "Mostrar contas na barra lateral";
+"advanced_setting_show_accounts_in_sidebar_description" = "Mostrar uma lista de suas contas na barra lateral.";
+"advanced_setting_group_accounts_in_sidebar_title" = "Agrupar contas na barra lateral";
+"advanced_setting_group_accounts_in_sidebar_description" = "Agrupe suas contas na barra lateral por tipo.";
+"advanced_setting_show_categories_in_sidebar_title" = "Mostrar categorias na barra lateral";
+"advanced_setting_show_categories_in_sidebar_description" = "Mostrar uma lista das suas categorias na barra lateral.";
+"advanced_setting_group_categories_in_sidebar_title" = "Agrupar categorias na barra lateral";
+"advanced_setting_group_categories_in_sidebar_description" = "Agrupe suas categorias na barra lateral por pasta.";
+
+"advanced_setting_select_time_automatically_title" = "Seleção automática de horário";
+"advanced_setting_select_time_automatically_description" = "Selecionar automaticamente a hora atual para novas transações.";
+"advanced_setting_select_location_automatically_title" = "Seleção automática de localização";
+"advanced_setting_select_location_automatically_description" = "Selecione automaticamente o local atual para novas transações.";
+"advanced_setting_save_photos_in_library_title" = "Salvar fotos na biblioteca";
+"advanced_setting_save_photos_description" = "Salvar automaticamente as fotos capturadas na biblioteca de fotos.";
+"advanced_setting_consider_pending_items_title" = "Considerar transações pendentes";
+"advanced_setting_consider_pending_items_description" = "Incluir transações pendentes ao calcular saldos de contas, saldos, totais, etc.";
+
+"advanced_setting_enable_exact_times_title" = "Inserir horários exatos";
+"advanced_setting_enable_exact_times_description" = "Selecione os horários exatos usando o seletor de minutos para transações (por exemplo, 9h41min).";
+"advanced_setting_reverse_keyboard_title" = "Teclado invertido";
+"advanced_setting_reverse_keyboard_description" = "Inverte verticalmente o layout do teclado numérico para corresponder ao estilo de uma calculadora tradicional.";
+"advanced_setting_enable_haptic_keyboard_title" = "Feedback tátil do teclado";
+"advanced_setting_enable_haptic_keyboard_description" = "Receba feedback tátil ao inserir valores monetários usando o teclado.";
+"advanced_setting_enable_live_activities_title" = "Atividades ao Vivo";
+"advanced_setting_enable_live_activities_description" = "Veja seu saldo atual e muito mais na Ilha Dinâmica (Dynamic Island), bem como na tela de bloqueio.";
+"advanced_setting_ask_for_feedback_title" = "Solicitar feedback";
+"advanced_setting_ask_for_feedback_description" = "Permitir que o aplicativo peça feedback ocasionalmente.";
+
+/* Cloud Sync Status */
+"cloud_sync_status_not_logged_in" = "Login não efetuado no iCloud";
+"cloud_sync_status_not_started" = "Não sincronizado";
+"cloud_sync_status_no_network" = "Sem conexão com a Internet";
+"cloud_sync_status_in_progress" = "Sincronizando...";
+"cloud_sync_status_succeeded" = "Totalmente sincronizado";
+"cloud_sync_status_quota_exceeded" = "O armazenamento do iCloud está cheio. Libere algum espaço e tente novamente.";
+"cloud_sync_status_limit_exceeded" = "Você atingiu o limite de upload/download do iCloud. Aguarde um momento e tente novamente mais tarde.";
+"cloud_sync_status_network_failure" = "Ocorreu um erro de rede. Tente novamente mais tarde.";
+"cloud_sync_status_service_unavailable" = "O iCloud está temporariamente indisponível. Tente novamente mais tarde.";
+"cloud_sync_status_request_rate_limited" = "Você fez muitas solicitações ao iCloud em um curto período. Aguarde um momento e tente novamente mais tarde.";
+"cloud_sync_status_request_unknown_error" = "Ocorreu um erro desconhecido. Tente novamente mais tarde.";
+
+/* Alert Views */
+"alert_share_app_type_selection_title" = "O que gostaria de compartilhar?";
+"alert_share_app_type_selection_link_button" = "Link";
+"alert_share_app_type_selection_qrcode_button" = "Código QR";
+
+"alert_reset_app_title" = "Redefinir aplicativo";
+"alert_reset_app_message" = "Tem certeza que deseja redefinir o aplicativo para as configurações padrão? Isto irá excluir permanentemente todos os seus dados armazenados neste dispositivo e no iCloud.";
+
+"alert_error_title" = "Ocorreu um erro 😢";
+
+/* Social Media */
+"follow_on_social_media" = "Siga \"%@\" nas mídias sociais";
+
+/* Copyright */
+"version" = "Versão";
+"developed_by" = "Desenvolvido por %@ 👨🏻‍💻";
+
+
+/* MARK: - Passcode View */
+/* Titles */
+"passcode_view_enter_passcode_title" = "Insira a senha";
+"passcode_view_create_passcode_title" = "Criar senha";
+"passcode_view_confirm_passcode_title" = "Confirmar senha";
+"passcode_view_authenticate_reason" = "Autenticação do usuário";
+
+/* Alert Views */
+"alert_set_passcode_type_title" = "Escolha uma opção de senha";
+
+
+/* MARK: - Welcome View */
+/* Titles */
+"welcome_view_title" = "Bem-vindo ao";
+"privacy_policy_title" = "Política de Privacidade";
+
+/* Sections */
+"welcome_view_overview_section_title" = "Resumo";
+"welcome_view_legal_documents_section_title" = "Mais informações";
+
+/* Overview */
+"privacy_overview_datastorage_title" = "Armazenamento seguro de dados";
+"privacy_overview_datastorage_description" = "Suas finanças são privadas – e devem permanecer assim. É por isso que os seus dados são armazenados exclusivamente no seu dispositivo ou (opcionalmente) no seu iCloud pessoal.";
+
+"privacy_overview_privacy_control_title" = "Você está no controle";
+"privacy_overview_privacy_control_description" = "Quer se trate dos seus dados salvos, da utilização da sua localização ou do acesso à sua câmera, você está sempre no controle. Por exemplo, você pode excluir facilmente seus dados redefinindo o aplicativo e as permissões de acesso do aplicativo são ajustadas a qualquer momento.";
+
+/* Footer */
+"welcome_view_value_description" = "Controle todas suas finanças com facilidade: Insira seu orçamento, obtenha insights e acompanhe todas as suas receitas e despesas.";
+"welcome_view_agreement_description" = "Ao clicar em \"Aceitar\" você concorda com %@.";
+
+
+/* MARK: - New Features View */
+/* Titles */
+"new_features_view_title" = "Novos recursos";
+
+/* Buttons */
+"new_features_view_rate_app_button" = "Avaliar o aplicativo";
+"new_features_view_close_button" = "Talvez mais tarde";
+
+
+/* MARK: - Rate App View */
+/* Titles */
+"purchase_success_view_title" = "Obrigado!";
+
+/* Messages */
+"purchase_success_view_info_message" = "Se você gosta do aplicativo, por favor, escreva uma avaliação positiva na App Store. Isso realmente ajuda muito e motiva a melhorar continuamente o aplicativo. 😊";
+"purchase_success_view_info_message_info" = "\n\nNota: Ao mudar de uma assinatura para uma compra vitalícia, lembre-se de cancelar sua assinatura existente depois.";
+
+/* Buttons */
+"purchase_success_view_rate_app_button" = "Avaliar o aplicativo";
+"purchase_success_view_close_button" = "Talvez mais tarde";
+
+
+/* MARK: - Upgrade View */
+/* Titles */
+"upgrade_view_title" = "Versão Completa";
+
+/* Info */
+"upgrade_info_description" = "Este recurso só está disponível na versão completa:";
+"upgrade_sharing_info_description" = "Utilizável com até cinco pessoas";
+
+/* Discount */
+"upgrade_discount_title" = "Oferta Especial 🌟";
+"upgrade_discount_multiple_title" = "Poupe até %d%%!";
+"upgrade_discount_montly_subscription_title" = "Economize %d%% na assinatura mensal!";
+"upgrade_discount_yearly_subscription_title" = "Economize %d%% na assinatura anual!";
+"upgrade_discount_lifetime_purchase_title" = "Economize %d%% na compra única!";
+"upgrade_discount_ends_in" = "Termina em";
+
+/* Sections */
+"upgrade_info_section_title" = "Informações";
+"upgrade_reviews_section_title" = "Avaliações";
+
+/* Messages */
+"apply_for_discount_text" = "Você é estudante ou precisa de ajuda financeira?\nClique aqui para solicitar um desconto.";
+"apply_for_discount_highlighted_text" = "Clique aqui para solicitar um desconto.";
+
+/* Features */
+"upgrade_features" = "Recursos";
+"upgrade_more_features" = "Mais recursos";
+"upgrade_features_description" = "Abaixo estão todos os recursos que serão desbloqueados comprando a versão completa:";
+"upgrade_feature_unlimited_accounts_title" = "Contas adicionais";
+"upgrade_feature_unlimited_accounts_description" = "Crie contas adicionais e atribua transações a elas para uma visão ainda melhor de suas receitas e despesas.";
+"upgrade_feature_unlimited_categories_and_tags_title" = "Categorias e tags ilimitadas";
+"upgrade_feature_unlimited_categories_and_tags_description" = "Crie categorias e tags ilimitadas que você pode adicionar às transações para melhor organizá-las.";
+"upgrade_feature_extended_analyses_title" = "Análise expandida";
+"upgrade_feature_extended_analyses_description" = "Beneficie de análises adicionais e de uma previsão expandida dos saldos e transações futuras das suas contas.";
+"upgrade_feature_unlimited_budgetbooks_title" = "Múltiplos Cadernos de Orçamento";
+"upgrade_feature_unlimited_budgetbooks_description" = "Crie vários Cadernos de Orçamento para que, por exemplo, várias pessoas possam usar o seu próprio em um dispositivo, ou no caso de você querer compartilhar um Caderno de Orçamento separado (por exemplo, para férias).";
+"upgrade_feature_security_title" = "Dados seguros";
+"upgrade_feature_security_description" = "Proteja os seus dados com %@.";
+"upgrade_feature_security_description_passcode" = "Proteja os seus dados criando uma senha";
+"upgrade_feature_security_description_biometric" = " ou use %@";
+"upgrade_feature_currency_converter_title" = "Conversor de moeda";
+"upgrade_feature_currency_converter_description" = "Use o conversor de moeda embutido para converter automaticamente os valores em uma das mais de 150 moedas estrangeiras.";
+"upgrade_feature_customization" = "Personalização";
+"upgrade_feature_customization_description" = "Escolha entre várias cores de destaque e ícones para personalizar o aplicativo ao seu gosto.";
+"upgrade_feature_sharedbudget_books_title" = "Compartilhar Cadernos de Orçamento";
+"upgrade_feature_sharedbudget_books_description" = "Compartilhe seus Cadernos de Orçamento, incluindo contas, categorias, transações e orçamentos para colaborar com uma ou mais pessoas.";
+"upgrade_feature_receipt_scanner_title" = "Digitalizar recibos";
+"upgrade_feature_receipt_scanner_description" = "Use o scanner integrado para digitalizar recibos e reconhecer automaticamente o valor e o nome do comerciante.";
+"upgrade_feature_widgets_title" = "Widgets da tela inicial e de bloqueio";
+"upgrade_feature_widgets_description" = "Com a ajuda dos widgets, você pode ver suas receitas e despesas atuais, seus saldos de conta e muito mais em um piscar de olhos, sem ter que abrir o aplicativo. Para visualizar os widgets, edite sua tela inicial ou de bloqueio, abra a visualização \"Adicionar Widget\" e selecione este aplicativo.";
+"upgrade_feature_reminders_title" = "Criar lembretes";
+"upgrade_feature_reminders_description" = "Crie lembretes para suas transações planejadas para receber notificações push (também offline).";
+"upgrade_feature_csv_title" = "Importação e exportação de CSV";
+"upgrade_feature_csv_description" = "Importe e exporte suas transações usando um arquivo CSV para transferir dados de seu banco ou outros aplicativos.";
+"upgrade_feature_remove_ads_title" = "Sem anúncios";
+"upgrade_feature_remove_ads_description" = "Você não verá mais anúncios para a versão completa no aplicativo.";
+"upgrade_feature_support_title" = "Apoio ao desenvolvimento";
+"upgrade_feature_support_description" = "Você está apoiando um jovem desenvolvedor e, portanto, o desenvolvimento contínuo do aplicativo! 😊";
+
+/* Reviews */
+"user_review_title_de" = "Aplicativo incrível";
+"user_review_description_de" = "O aplicativo é muito bem desenhado e funcional. Ele atende a todas as minhas necessidades e o suporte é muito rápido e útil. Só posso recomendá-lo.";
+"user_review_title_hr" = "Belo aplicativo";
+"user_review_description_hr" = "Aplicativo rico em recursos, com uma UX fácil de usar. Tentei muitas alternativas no iOS, nenhuma delas atendeu às minhas necessidades da maneira que este aplicativo faz. Vale o dinheiro.";
+"user_review_title_bg" = "Suporte excepcional";
+"user_review_description_bg" = "Excelente aplicativo com um excelente suporte ao cliente. E tem um preço muito razoável para a qualidade do software.";
+"user_review_title_us" = "Ótimo aplicativo até agora";
+"user_review_description_us" = "Grande fã deste ser um aplicativo disponível no iOS, iPad e macOS para que eu possa atualizá-lo em qualquer lugar. Também é muito bom ver que não há nenhuma conta necessária ou coleta de dados, o que parece raro nos dias de hoje, mas importante para mim para aplicativos financeiros.";
+"user_review_title_uk" = "É este!";
+"user_review_description_uk" = "Há mais de dois anos que andava à procura deste aplicativo. Queria um gerenciador financeiro para celular que fosse concebido em torno de uma tela de visão geral bonita, que permitisse a inserção fácil de novos dados e a possibilidade de pesquisar mais informações quando necessário!";
+"user_review_title_es" = "Melhor aplicativo de orçamento";
+"user_review_description_es" = "Simplesmente o melhor que eu tentei. Eu acho que ainda é um aplicativo novo, mas definitivamente você pode ver o potencial que tem.";
+"user_review_title_fr" = "Aplicativo soberbo e rico em recursos";
+"user_review_description_fr" = "Estou usando o aplicativo há alguns meses e gosto muito. Parabéns pelo seu trabalho e mal posso esperar para ver como será o aplicativo em alguns meses :)";
+"user_review_title_it" = "Simplesmente ótimo";
+"user_review_description_it" = "Finalmente. Eu estava procurando por essa solução há anos. Use-a com o gatilho de atalho de transação do iOS, adorei o design. E gosto do recurso de pagamento único. Continue com o excelente trabalho!";
+"user_review_title_ch" = "Grande suporte";
+"user_review_description_ch" = "Grande suporte - resolução de problemas rápida e descomplicada. Sinto-me levado a sério como usuário.";
+"user_review_title_pl" = "Muito agradável de usar";
+"user_review_description_pl" = "O aplicativo é um excelente rastreador e planejador de orçamento que uso diariamente. Além disso, o desenvolvedor está muito atento à sua comunidade, apesar de seu pequeno tamanho.";
+
+/* Products */
+"monthly_subscription_title" = "1";
+"yearly_subscription_title" = "12";
+"lifetime_purchase_title" = "∞";
+
+"monthly_subscription_subtitle" = "Mês";
+"yearly_subscription_subtitle" = "Meses";
+"lifetime_purchase_subtitle" = "Ilimitado";
+
+"product_discount_header_title" = "Economize %d%%";
+
+/* Buttons */
+"upgrade_is_active_button" = "Ativo";
+"upgrade_purchase_button" = "Comprar";
+"upgrade_subscribe_button" = "Assinar";
+"upgrade_free_trial_button" = "Teste gratuito";
+"upgrade_restore_button" = "Restaurar compras";
+"upgrade_restore_in_progress_button" = "Por favor, aguarde...";
+
+"subscription_button_info_text" = "Cancelável a qualquer momento.";
+"subscription_trial_button_info_text" = "%d %@ de teste gratuito. Depois, %@ por %@.";
+"lifetime_purchase_button_info_text" = "Desbloqueie a versão completa uma vez (sem assinatura).";
+
+/* Alert Views */
+"alert_upgrade_view_purchase_success_title" = "Compra bem-sucedida 🎉";
+"alert_upgrade_view_purchase_success_message" = "Obrigado pelo apoio! 😊";
+"alert_upgrade_view_purchase_success_message_info" = "\n\nNota: Se mudar de uma assinatura para uma compra única, lembre-se de cancelar a sua assinatura anterior posteriormente.";
+"alert_upgrade_view_purchase_error_message" = "Sua compra não pôde ser concluída.";
+"alert_upgrade_view_purchase_error_store_problem_message" = "Houve um problema com a App Store.\n\nNota: Às vezes a compra só funciona se você confirmar com sua senha em vez do Touch ID / Face ID.\n\nPor exemplo, se você estiver usando o Face ID, basta cobrir a câmera frontal e tentar novamente para ver a caixa de diálogo da senha.";
+"alert_upgrade_view_purchase_error_not_allowed_message" = "Não são permitidas compras neste dispositivo.";
+"alert_upgrade_view_purchase_error_invalid_message" = "Verifique seu método de pagamento e tente novamente mais tarde. Se o erro persistir, contate o suporte.";
+"alert_upgrade_view_purchase_error_network_message" = "Verifique sua conexão com a Internet e tente novamente mais tarde. Se o erro persistir, contate o suporte.";
+
+"alert_upgrade_view_load_products_error_message" = "Os produtos não puderam ser carregados. Verifique a sua conexão com a Internet e tente novamente mais tarde. Se o erro persistir, contate o suporte.";
+
+"alert_upgrade_view_restore_success_title" = "Compras Restauradas";
+"alert_upgrade_view_restore_success_message" = "Suas compras foram restauradas com sucesso! 😊";
+"alert_upgrade_view_restore_error_message" = "Suas compras não puderam ser restauradas. Por favor, tente novamente mais tarde.";
+"alert_upgrade_view_restore_nothing_to_do_title" = "Nenhuma compra disponível 😢";
+"alert_upgrade_view_restore_nothing_to_do_message" = "Não foi possível encontrar nenhuma compra para restaurar.";
+
+
+/* MARK: - Upgrade FAQ View */
+/* Titles */
+"upgrade_faq_view_title" = "FAQ";
+
+/* Sections */
+"upgrade_faq_general_section_title" = "Geral";
+"upgrade_faq_purchases_section_title" = "Compras e assinaturas";
+
+/* Items */
+"upgrade_faq_about_title" = "O que é o Budget Flow?";
+"upgrade_faq_about_value" = "Budget Flow é um aplicativo de rastreamento de orçamento moderno e fácil de usar para todos que querem acompanhar suas finanças e gerenciar suas despesas de forma eficaz.";
+"upgrade_faq_developer_title" = "Quem desenvolveu o aplicativo?";
+"upgrade_faq_developer_value" = "O Budget Flow foi iniciado como um projeto paralelo e desde então foi completamente concebido, desenvolvido e mantido por mim, Fabian Hasse. Sou um desenvolvedor de software entusiasta com mais de 10 anos de experiência e trabalho com muita paixão para desenvolver o melhor aplicativo de orçamento e controle de despesas na App Store.";
+"upgrade_faq_free_use_title" = "O aplicativo também pode ser usado gratuitamente?";
+"upgrade_faq_free_use_value" = "Sim, você pode usar as funções básicas do aplicativo, como criar transações, de forma totalmente gratuita.\n\nAlém disso, o aplicativo oferece um período de teste para a versão completa para que você possa experimentá-lo com antecedência antes de decidir comprar ou assinar a versão completa.";
+"upgrade_faq_security_title" = "Os meus dados estão seguros?";
+"upgrade_faq_security_value" = "As suas finanças são privadas – e devem permanecer assim. É por isso que os seus dados são armazenados exclusivamente no seu dispositivo ou (opcionalmente) no seu iCloud pessoal.";
+"upgrade_faq_why_subscription_title" = "Por que a versão completa é oferecida como uma assinatura?";
+"upgrade_faq_why_subscription_value" = "Meu objetivo é desenvolver um aplicativo de alta qualidade que ofereça a você como usuário novos recursos e melhorias regularmente. No entanto, para atingir esse objetivo, o aplicativo precisa de receita contínua para se financiar e ser economicamente sustentável.\n\nO que muitos não sabem: desenvolver e manter um aplicativo leva muito tempo. No caso do Budget Flow, por exemplo, foram necessários quase dois anos e milhares de horas de trabalho desde a ideia até o desenvolvimento e testes até que a primeira versão pudesse ser lançada na App Store.\n\nComo cliente, você se beneficia em particular de atualizações e melhorias regulares através do modelo de assinatura, bem como um bom suporte para garantir que você continue satisfeito. Você também tem a oportunidade de experimentar o aplicativo gratuitamente com antecedência para garantir que ele atenda às suas necessidades, você pode alterar ou cancelar a assinatura a qualquer momento se mudar de ideia.\n\nNo geral, um modelo de assinatura oferece muitos benefícios para você como cliente e uma melhor experiência do usuário por meio de atualizações contínuas e suporte em comparação com uma compra única. A longo prazo, uma compra única infelizmente não seria sustentável, pois esse modelo de negócio exige que novos usuários continuem comprando o aplicativo para garantir a continuação do desenvolvimento.\n\nEntão, se você gosta do aplicativo, eu ficaria muito feliz if você apoiasse meu trabalho para que eu possa continuar a oferecer ainda mais recursos excelentes no futuro!❤️";
+"upgrade_faq_multiple_devices_title" = "Posso usar a versão completa em vários dispositivos?";
+"upgrade_faq_multiple_devices_value" = "Sim, você pode usar a versão completa do Budget Flow em todos os seus dispositivos Apple com o mesmo ID Apple. Uma vez que o aplicativo é sincronizado através do iCloud, pode alternar facilmente entre os seus dispositivos e ter sempre acesso aos seus dados financeiros e configurações.";
+"upgrade_faq_multiple_people_title" = "Posso usar a versão completa com várias pessoas?";
+"upgrade_faq_multiple_people_value" = "Sim, você pode compartilhar a compra única, bem como a assinatura da versão completa com até cinco pessoas dentro de um grupo familiar. Tudo o que tem de fazer é ativar o compartilhamento familiar nas configurações do sistema e adicionar as outras pessoas ao grupo.";
+"upgrade_faq_cancel_subscription_title" = "Como posso cancelar a minha assinatura?";
+"upgrade_faq_cancel_subscription_value" = "Você pode cancelar a sua assinatura a qualquer momento utilizando o seu ID Apple nas preferências do sistema.";
+"upgrade_faq_subscription_data_loss_title" = "Os meus dados serão perdidos se eu cancelar a minha assinatura?";
+"upgrade_faq_subscription_data_loss_value" = "Não. Qualquer coisa que você criar ao assinar a versão completa ainda estará disponível if você voltar para a versão gratuita.";
+"upgrade_faq_refund_title" = "Como posso obter um reembolso?";
+"upgrade_faq_refund_value" = "Pagamentos feitos através da App Store são reembolsáveis apenas pela Apple. Para receber um reembolso, você tem de contatar o Suporte Apple no prazo de 14 dias após a compra.";
+"upgrade_faq_switch_plan_title" = "É possível mudar de uma assinatura para uma compra única posteriormente?";
+"upgrade_faq_switch_plan_value" = "Sim, você pode mudar de uma assinatura ativa para uma compra única a qualquer momento, comprando o produto correspondente no aplicativo. No entanto, lembre-se de cancelar sua assinatura anterior para não pagar mais do que uma vez.";
+
+
+/* MARK: - User Feedback */
+"user_feedback" = "feedback";
+
+/* Buttons */
+"user_feedback_message_title" = "Olá, aqui é Fabian, o desenvolvedor do Budget Flow. Você tem um momento para dar algum feedback sobre o aplicativo? 😊";
+
+/* Alert Views */
+"alert_user_feedback_title" = "Você gosta do aplicativo?";
+
+"alert_user_feedback_like_title" = "Obrigado! 🎉";
+"alert_user_feedback_like_message" = "Se você gosta do aplicativo, por favor, escreva uma avaliação positiva na App Store. Isso realmente ajuda muito e motiva a melhorar continuamente o aplicativo. 😊";
+"alert_user_feedback_rate_app_button" = "Avaliar o aplicativo";
+"alert_user_feedback_maybe_later_button" = "Talvez mais tarde";
+
+"alert_user_feedback_dislike_title" = "Sugestões? 🤔";
+"alert_user_feedback_dislike_message" = "Lamento saber que você ainda não gosta do aplicativo. Para mudar isso, conte-me suas ideias e sugestões para melhorias. 😊";
+"alert_user_feedback_contact_developer_button" = "Contatar o desenvolvedor";
+
+
+/* MARK: - Progress View */
+"progress_view_load_images_title" = "Carregando fotos...";
+"progress_view_load_images_subtitle" = "Nota: Se utilizar a Fototeca do iCloud, o download das suas fotos poderá demorar algum tempo.";
+"progress_view_load_documents_title" = "Carregando documentos...";
+"progress_view_load_documents_subtitle" = "Nota: Se você usa o iCloud Drive, o download dos seus documentos poderá demorar algum tempo.";
+"progress_view_import_csv_title" = "Importando dados...";
+"progress_view_import_csv_subtitle" = "Aguarde...";
+
+
+/* MARK: - Widgets */
+"chart_widget_title" = "Gráfico";
+"chart_widget_description" = "Este widget exibe um gráfico dos saldos de sua conta, seu saldo atual ou um detalhamento de suas receitas e despesas para o período de tempo selecionado.";
+
+"overview_widget_title" = "Visão Geral";
+"overview_widget_description" = "Este widget mostra uma visão geral dos saldos da sua conta, do seu saldo atual ou um total de receitas e despesas para o período selecionado.";
+
+"upcoming_transactions_widget_title" = "Planejadas";
+"upcoming_transactions_widget_description" = "Este widget mostra sua próxima transação planejada.";
+
+"budget_widget_title" = "Orçamento";
+"budget_widget_description" = "Este widget mostra um orçamento específico para o período selecionado.";
+"budget_widget_no_budget_title" = "Nenhum orçamento selecionado";
+
+"suggestion_widget_title" = "Sugerido";
+"suggestion_widget_description" = "Este widget mostra uma categoria sugerida com base na data atual para a qual você pode criar uma nova transação.";
+
+"quick_actions_widget_title" = "Entrada rápida";
+"quick_actions_widget_description" = "Este widget permite que você adicione rapidamente novas transações.";
+"quick_actions_widget_new_title" = "Novo";
+
+"widget_upgrade_locked_title" = "Bloqueado";
+"widget_upgrade_necessary_title" = "Versão completa";
+"widget_upgrade_necessary_title_long" = "Versão completa necessária";
+"widget_upgrade_necessary_description" = "É necessária uma atualização para a versão completa para usar este widget.";
+"widget_upgrade_necessary_highlighted_text" = "versão completa";
+
+
+/* MARK: - Add Item Form View */
+/* Alert Views */
+/* Info */
+"alert_no_budget_book_selected_title" = "Nenhum Caderno de Orçamento selecionado";
+"alert_upgrade_necessary_title" = "Versão completa";
+"alert_upgrade_necessary_description" = "Para utilizar este recurso, precisa de atualizar para a versão completa. Pode ser ativada no aplicativo.";
+
+/* Dismiss */
+"alert_confirm_dismiss_title" = "Tem certeza que deseja descartar suas alterações?";
+
+/* Delete */
+"alert_confirm_delete_budgetbook_title" = "Tem certeza de que quer excluir este Caderno de Orçamento? Todas as contas, categorias, transações e orçamentos associados também serão excluídos.";
+"alert_confirm_delete_budgetbook_button" = "Excluir Caderno de Orçamento";
+"alert_confirm_delete_budgetbook_multiple_title" = "Tem certeza de que deseja excluir todos os Cadernos de Orçamento selecionados? Todas as contas, categorias, transações e orçamentos associados também serão excluídos.";
+"alert_confirm_delete_budgetbook_multiple_button" = "Excluir Cadernos de Orçamento";
+
+"alert_confirm_delete_account_title" = "Tem certeza de que deseja excluir essa conta? Todas as transações associadas também serão excluídas.";
+"alert_confirm_delete_account_button" = "Excluir conta";
+"alert_confirm_delete_account_multiple_title" = "Tem certeza de que deseja excluir todas as contas selecionadas? Todas as transações associadas também serão excluídas.";
+"alert_confirm_delete_account_multiple_button" = "Excluir contas";
+
+"alert_confirm_delete_categorygroup_title" = "Tem certeza de que deseja excluir esta pasta? Todas as categorias, transações e orçamentos associados também serão excluídos (se necessário).";
+"alert_confirm_delete_categorygroup_button" = "Excluir pasta";
+"alert_confirm_delete_categorygroup_multiple_title" = "Tem certeza de que deseja excluir todas as pastas selecionadas? Todas as categorias, transações e orçamentos relacionados também serão excluídos (se necessário).";
+"alert_confirm_delete_categorygroup_multiple_button" = "Excluir pastas";
+
+"alert_confirm_delete_category_title" = "Tem certeza de que deseja excluir essa categoria? Todos os orçamentos associados também serão excluídos (se necessário).";
+"alert_confirm_delete_category_button" = "Excluir categoria";
+"alert_confirm_delete_category_multiple_title" = "Tem certeza de que deseja excluir todas as categorias selecionadas? Todas as transações e orçamentos associados também serão excluídos.";
+"alert_confirm_delete_category_multiple_button" = "Excluir categorias";
+
+"alert_confirm_delete_payee_title" = "Tem certeza de que pretende excluir este beneficiário?";
+"alert_confirm_delete_payee_button" = "Excluir beneficiário";
+"alert_confirm_delete_payee_multiple_title" = "Tem certeza de que deseja excluir todos os beneficiários selecionados?";
+"alert_confirm_delete_payee_multiple_button" = "Excluir beneficiários";
+
+"alert_confirm_delete_tag_title" = "Tem certeza que deseja excluir esta tag?";
+"alert_confirm_delete_tag_button" = "Excluir tag";
+"alert_confirm_delete_tag_multiple_title" = "Tem certeza de que deseja excluir todas as tags selecionadas?";
+"alert_confirm_delete_tag_multiple_button" = "Excluir tags";
+
+"alert_confirm_delete_reminder_title" = "Tem certeza de que deseja excluir este lembrete?";
+"alert_confirm_delete_reminder_button" = "Excluir lembrete";
+"alert_confirm_delete_reminder_multiple_title" = "Tem certeza de que deseja excluir todos os lembretes selecionados?";
+"alert_confirm_delete_reminder_multiple_button" = "Excluir lembretes";
+
+"alert_confirm_delete_transaction_title" = "Tem certeza de que deseja excluir esta transação?";
+"alert_confirm_delete_assigned_transaction_title" = "Você também deseja excluir todas as transações atribuídas?";
+"alert_confirm_delete_transaction_button" = "Excluir transação";
+"alert_confirm_delete_transaction_multiple_title" = "Tem certeza de que deseja excluir todas as transações selecionadas?";
+"alert_confirm_delete_transaction_multiple_button" = "Excluir transações";
+
+"alert_confirm_delete_imageitem_title" = "Tem certeza de que deseja excluir esta foto?";
+"alert_confirm_delete_imageitem_button" = "Excluir foto";
+"alert_confirm_delete_imageitem_multiple_title" = "Tem certeza de que deseja excluir todas as fotos selecionadas?";
+"alert_confirm_delete_imageitem_multiple_button" = "Excluir fotos";
+
+"alert_confirm_delete_documentitem_title" = "Tem certeza que deseja excluir este documento?";
+"alert_confirm_delete_documentitem_button" = "Excluir documento";
+"alert_confirm_delete_documentitem_multiple_title" = "Tem certeza de que deseja excluir todos os documentos selecionados?";
+"alert_confirm_delete_documentitem_multiple_button" = "Excluir documentos";
+
+"alert_confirm_delete_budget_title" = "Tem certeza de que quer excluir este orçamento?";
+"alert_confirm_delete_budget_button" = "Excluir orçamento";
+"alert_confirm_delete_budget_multiple_title" = "Tem certeza de que deseja excluir todos os orçamentos selecionados?";
+"alert_confirm_delete_budget_multiple_button" = "Excluir orçamentos";
+
+"alert_confirm_delete_backupitem_title" = "Tem certeza de que deseja excluir este backup?";
+"alert_confirm_delete_backupitem_button" = "Excluir backup";
+
+"alert_confirm_delete_contra_entry_title" = "Esta transação é uma transferência. Gostaria também de excluir a contrapartida?";
+
+/* Updates */
+"alert_confirm_update_contra_entry_title" = "Esta transação é uma transferência. Gostaria também de atualizar a contrapartida?";
+"alert_confirm_update_transaction_multiple_title" = "Esta transação pertence a um grupo. O que exatamente você quer salvar?";
+"alert_confirm_update_transaction_single_button" = "Salvar só esta";
+"alert_confirm_update_transaction_all_button" = "Salvar esta e as futuras";
+
+/* End Repetition */
+"alert_confirm_end_repetition_for_transaction_title" = "Tem certeza de que quer parar de repetir essa transação?";
+"alert_confirm_end_repetition_for_transaction_button" = "Fim da repetição";
+"alert_confirm_end_repetition_for_transaction_multiple_title" = "Tem certeza de que deseja que todas as transações selecionadas parem de se repetir?";
+"alert_confirm_end_repetition_for_transaction_multiple_button" = "Fim da repetição";
+
+/* Currency Selection */
+"alert_change_currency_or_exchange_rate_title" = "O que exatamente você quer mudar?";
+"alert_change_currency_button" = "Moeda";
+"alert_change_exchange_rate_button" = "Taxa de câmbio";
+
+
+/* MARK: - Currency Selection View */
+/* Titles */
+"currency_selection_title" = "Moedas";
+
+/* Info */
+"currency_selection_info_title" = "Descrição";
+"currency_selection_info_description" = "Escolha a moeda padrão para transações existentes e futuras.";
+
+/* Sections */
+"default_currency_section_title" = "Moeda padrão";
+"suggested_currencies_section_title" = "Sugestões";
+
+/* Messages */
+"no_currencies_found_title" = "Nenhuma moeda encontrada";
+"currency_selection_search_placeholder_message" = "Procurar um nome de moeda ou a sua abreviação";
+
+/* Buttons */
+"change_default_currency_button" = "Alterar moeda padrão";
+
+/* Alert Views */
+"alert_confirm_change_default_currency_title" = "Tem certeza de que deseja mudar sua moeda padrão? Isto irá converter todas as transações existentes para a nova moeda (%@).";
+"alert_confirm_change_default_account_currency_title" = "Tem certeza de que quer mudar a moeda? Isto irá converter todas as transações existentes desta conta para a nova moeda (%@).";
+
+
+/* MARK: - Currency Conversion View */
+/* Titles */
+"currency_conversion_title" = "Taxa de câmbio";
+"currency_conversion_last_synchronization_title" = "Atualizado: %@";
+"currency_conversion_synchronization_failed_title" = "Falha na sincronização";
+"currency_conversion_synchronization_failed_no_internet_title" = "Sem conexão com a Internet";
+
+/* Sections */
+"source_currency_section_title" = "De";
+"target_currency_section_title" = "Para";
+
+
+/* MARK: - Manage Item View */
+/* Titles */
+"manage_budgetbooks_title" = "Cadernos de Orçamento";
+"manage_accounts_title" = "Contas";
+"manage_categories_title" = "Categorias";
+"manage_category_groups_title" = "Pastas";
+"manage_payees_title" = "Beneficiários";
+"manage_tags_title" = "Tags";
+"manage_reminders_title" = "Lembretes";
+
+/* Info */
+"manage_reminders_info_title" = "Descrição";
+"manage_reminders_info_description" = "Crie lembretes personalizados ou adicione-os a transações futuras para que o aplicativo o notifique.";
+
+/* Sections */
+"shared_by_you_budgetbooks_section_title" = "Compartilhado por você";
+"shared_with_you_budgetbooks_section_title" = "Compartilhado com você";
+"not_shared_budgetbooks_section_title" = "Não compartilhado";
+"most_used_items_section_title" = "Mais Usados";
+"archived_items_section_title" = "Arquivados";
+"own_reminders_section_title" = "Lembretes próprios";
+
+/* Messages */
+"no_budget_books_found_title" = "Nenhum Caderno de Orçamento encontrado";
+"no_budget_books_found_message" = "Clique no botão \"+\" para adicionar um novo Caderno de Orçamento.";
+"no_budget_books_found_button_title" = "Novo Caderno de Orçamento";
+"no_budget_books_found_cloud_sync_message" = "Os dados existentes estão sendo carregados do iCloud. Aguarde um momento...\n\nAlternativamente, clique no botão \"+\" para adicionar um novo Caderno de Orçamento.";
+"no_budget_books_found_cloud_sync_message_short" = "Os dados existentes estão sendo carregados do iCloud. Por favor, aguarde um momento...";
+"budget_books_search_placeholder_message" = "Pesquisar pelo nome de um Caderno de Orçamento";
+
+"no_accounts_title" = "Sem contas";
+"no_accounts_found_title" = "Nenhuma conta encontrada";
+"no_accounts_found_message" = "Clique no botão \"+\" para adicionar uma nova conta.";
+"no_accounts_found_button_title" = "Nova Conta";
+"accounts_search_placeholder_message" = "Pesquisar por nome ou tipo de conta";
+
+"no_categories_found_title" = "Nenhuma categoria encontrada";
+"no_categories_found_message" = "Clique no botão \"+\" para adicionar uma nova categoria.";
+"no_categories_found_button_title" = "Nova Categoria";
+"categories_search_placeholder_message" = "Pesquisar por categoria ou nome de pasta";
+
+"no_category_groups_found_title" = "Nenhuma pasta encontrada";
+"no_category_groups_found_message" = "Clique no botão \"+\" para adicionar uma nova pasta.";
+"no_category_groups_found_button_title" = "Nova Pasta";
+"category_groups_search_placeholder_message" = "Pesquisar pelo nome de uma pasta";
+
+"no_payees_found_title" = "Nenhum beneficiário encontrado";
+"no_payees_found_message" = "Clique no botão \"+\" para adicionar um novo beneficiário.";
+"no_payees_found_button_title" = "Novo beneficiário";
+"payees_search_placeholder_message" = "Pesquisar pelo nome de um beneficiário";
+
+"no_tags_found_title" = "Nenhuma tag encontrada";
+"no_tags_found_message" = "Clique no botão \"+\" para adicionar uma nova tag.";
+"no_tags_found_button_title" = "Nova tag";
+"tags_search_placeholder_message" = "Pesquisar pelo nome de uma tag";
+
+"no_reminders_found_title" = "Nenhum lembrete encontrado";
+"no_reminders_found_message" = "Clique no botão \"+\" para adicionar um novo lembrete.";
+"no_reminders_found_button_title" = "Novo Lembrete";
+"reminders_search_placeholder_message" = "Pesquisar pelo título de um lembrete";
+
+/* Value */
+"balance" = "Saldo";
+
+
+/* MARK: - Add Item Form View */
+/* Titles */
+"form_title_edit" = "Editar";
+
+/* Sections */
+"form_name_section_title" = "Nome";
+"form_title_section_title" = "Título";
+"form_color_section_title" = "Cor";
+"form_icon_section_title" = "Ícone";
+"form_assignment_section_title" = "Atribuição";
+"form_miscellaneous_section_title" = "Diversos";
+
+/* Miscellaneous */
+"number_of_selected_items" = "%d selecionado(s)";
+
+
+/* MARK: - Add Budget Book Form View */
+/* Titles */
+"form_title_new_budgetbook" = "Novo Caderno de Orçamento";
+
+/* Items */
+"form_budgetbook_currency_title" = "Moeda";
+
+/* Buttons */
+"form_button_delete_budgetbook" = "Excluir Caderno de Orçamento";
+
+
+/* MARK: - Add Account Form View */
+/* Titles */
+"form_title_new_account" = "Nova conta";
+
+/* Sections */
+"form_billing_section_title" = "Faturamento automático";
+"form_transactions_section_title" = "Transações";
+"form_account_balance_section_title" = "Saldo da conta";
+
+/* Footer */
+"form_billing_footer_title" = "Ative este recurso para equilibrar automaticamente este cartão de crédito em um dia específico do mês (se necessário).";
+"form_transactions_footer_title" = "Ative este recurso para marcar automaticamente novas transações para esta conta como \"pendente\".";
+"form_account_balance_footer_title" = "Altere o saldo inicial/total para reconciliar manualmente o saldo da sua conta.";
+
+/* Items */
+"form_enable_automatic_billing_title" = "Ativado";
+"form_billing_day_title" = "Dia do faturamento";
+"form_mark_transactions_as_pending_title" = "Marcar como pendente";
+"form_account_type_title" = "Tipo de conta";
+"form_initial_balance_title" = "Saldo inicial";
+"form_total_balance_title" = "Saldo total";
+"form_use_as_default_account_title" = "Conta padrão";
+"form_account_currency_title" = "Moeda";
+
+/* Buttons */
+"form_button_archive_account" = "Arquivar conta";
+"form_button_unarchive_account" = "Desarquivar conta";
+"form_button_delete_account" = "Excluir conta";
+
+
+/* MARK: - Add Category Group Form View */
+/* Titles */
+"form_title_new_categorygroup" = "Nova pasta";
+
+/* Buttons */
+"form_button_delete_categorygroup" = "Excluir pasta";
+
+
+/* MARK: - Add Category Form View */
+/* Titles */
+"form_title_new_category" = "Nova categoria";
+
+/* Items */
+"form_category_group_title" = "Pasta";
+"form_category_group_none_type_value" = "Nenhuma";
+
+/* Buttons */
+"form_button_delete_category" = "Excluir categoria";
+
+
+/* MARK: - Add Payee Form View */
+/* Titles */
+"form_title_new_payee" = "Novo beneficiário";
+
+/* Footer */
+"form_assignment_default_entries_footer_title" = "Atribuir a este beneficiário uma conta, categoria ou local para usar por padrão para transações.";
+
+/* Items */
+"form_location_title" = "Localização";
+"form_location_none_type_value" = "Nenhuma";
+
+/* Buttons */
+"form_button_delete_payee" = "Excluir beneficiário";
+
+
+/* MARK: - Add Tag Form View */
+/* Titles */
+"form_title_new_tag" = "Nova tag";
+
+/* Buttons */
+"form_button_delete_tag" = "Excluir tag";
+
+
+/* MARK: - Add Reminder Form View */
+/* Titles */
+"form_title_new_reminder" = "Novo lembrete";
+
+/* Items */
+"form_is_enabled_title" = "Ativado";
+
+/* Buttons */
+"form_button_preview_reminder" = "Mostrar pré-visualização";
+"form_button_delete_reminder" = "Excluir lembrete";
+
+/* Notifications */
+"reminder_notification_title" = "Lembrete";
+
+
+/* MARK: - Add Transaction Form View */
+/* Titles */
+"form_title_new_income" = "Nova receita";
+"form_title_new_expense" = "Nova despesa";
+"form_title_new_transfer" = "Nova transferência";
+
+/* Sections */
+"form_date_section_title" = "Data";
+"form_reminder_section_title" = "Lembrete";
+"form_location_section_title" = "Localização";
+"form_notes_section_title" = "Notas";
+"form_currency_section_title" = "Moeda";
+"form_payment_status_section_title" = "Pagamento";
+"form_evaluation_section_title" = "Avaliação";
+"form_attachments_section_title" = "Anexos";
+"form_tags_section_title" = "Tags";
+
+/* Items */
+"form_account_title" = "Conta";
+"form_from_account_title" = "De";
+"form_to_account_title" = "Para";
+"form_account_none_type_value" = "Nenhuma";
+"form_category_title" = "Categoria";
+"form_categories_title" = "Categorias";
+"form_category_none_type_value" = "Nenhuma";
+"form_payee_title" = "Beneficiário";
+"form_payee_none_type_value" = "Nenhum";
+"form_tags_title" = "Tags";
+"form_tag_none_type_value" = "Nenhuma";
+"form_date_title" = "Data";
+"form_date_format_title" = "Formato de data";
+"form_time_title" = "Hora";
+"form_repetition_frequency_title" = "Repetir";
+"form_date_repetition_has_end_date_title" = "Fim";
+"form_date_repetition_end_date_title" = "Data de término";
+"form_reminder_title" = "Ativo";
+"form_reminder_none_type_value" = "Nenhum";
+"form_reminder_none_type_value_long" = "Sem lembrete";
+"form_reminder_on_due_value" = "No Vencimento";
+"form_location_none_type_value_long" = "Sem localização";
+"form_original_amount_title" = "Valor original";
+"form_exchange_rate_title" = "Taxa de câmbio";
+"form_is_selected_title" = "Selecionado";
+"form_is_pending_title" = "Pendente";
+"form_payed_by_title" = "Atribuído";
+"form_payed_by_none_type_value" = "Ninguém";
+"form_include_in_statistics_title" = "Estatísticas";
+"form_include_in_budgets_title" = "Orçamentos";
+
+/* Footer */
+"form_payment_status_footer_title" = "Marque o pagamento como \"pendente\" para que o valor não seja incluído nos cálculos.";
+"form_evaluation_footer_title" = "Exclua esta transação das estatísticas e/ou dos orçamentos para que seja considerada apenas no saldo da conta.";
+"form_reminded_transactions_is_invalid_footer_title" = "Nota: Para adicionar um lembrete a esta transação, uma data futura ou um intervalo de repetição deve ser selecionado.";
+
+/* Buttons */
+"form_button_delete_transaction" = "Excluir transação";
+"form_button_end_repetition_for_transaction" = "Fim da repetição";
+"form_button_clear_title" = "Remover";
+"form_button_today_title" = "Hoje";
+
+/* Miscellaneous */
+"receipt_total" = "Total";
+"receipt_amount" = "Valor";
+"receipt_to_pay" = "A pagar";
+
+/* Notifications */
+"transaction_notification_body" = "Valor: %@\nData: %@";
+"transaction_notification_body_notes" = "Notas: %@";
+
+
+/* MARK: - Add Budget Form View */
+/* Titles */
+"form_title_new_budget" = "Novo orçamento";
+
+/* Sections */
+"form_interval_section_title" = "Intervalo";
+
+/* Footer */
+"form_budget_amount_calculation_footer_title" = "O intervalo determina a frequência com que o orçamento é repetido, sendo o valor disponível apresentado automaticamente ajustado ao período selecionado.";
+
+/* Items */
+"form_is_cumulative_title" = "Cumulativo";
+
+/* Buttons */
+"form_button_delete_budget" = "Excluir orçamento";
+
+
+/* MARK: - Assign CSV Fields Form View */
+/* Titles */
+"form_title_csv_assign_fields" = "Atribuir campos";
+
+/* Info */
+"csv_assign_fields_info_title" = "Descrição";
+"csv_assign_fields_info_description" = "Atribua as colunas do arquivo CSV a serem importadas aos campos correspondentes.";
+
+/* Sections */
+"form_general_section_title" = "Geral";
+
+/* Footer */
+"form_invalid_footer_title" = "Erro:";
+"form_invalid_amount_footer_title" = "Os valores de \"%@\" não são valores monetários válidos.";
+"form_invalid_currency_footer_title" = "Os valores de \"%@\" não são moedas válidas.";
+"form_invalid_exchange_rate_footer_title" = "Os valores para \"%@\" não são valores numéricos válidos.";
+"form_invalid_date_format_footer_title" = "A data e/ou formato selecionados são inválidos.";
+"form_type_footer_title" = "Informação: Selecione \"%@\" para calcular o tipo de transação com base no sinal do valor.";
+"form_date_format_footer_title" = "Exemplo: %@";
+
+/* Items */
+"form_type_title" = "Tipo";
+"form_amount_title" = "Valor";
+"form_source_currency_title" = "Moeda de origem";
+"form_target_currency_title" = "Moeda de destino";
+"form_budget_book_title" = "Caderno de Orçamento";
+"form_notes_title" = "Notas";
+"form_skip_zero_amounts_title" = "Ignorar valores \"0\"";
+"form_skip_duplicates_title" = "Ignorar duplicados";
+"form_csv_assign_field_none_type_value" = "Não atribuído";
+
+
+/* MARK: - Color Selection View */
+/* Titles */
+"color_selection_title" = "Cores";
+
+/* Messages */
+"no_colors_found_title" = "Nenhuma cor encontrada";
+"color_selection_search_placeholder_message" = "Procurar uma cor ou um nome de grupo";
+
+
+/* MARK: - Icon Selection View */
+/* Titles */
+"icon_selection_title" = "Ícones";
+
+/* Messages */
+"no_icons_found_title" = "Nenhum ícone encontrado";
+"icon_selection_search_placeholder_message" = "Procurar um rótulo de ícone ou um nome de grupo";
+
+
+/* MARK: - Location Selection View */
+/* Titles */
+"location_selection_title" = "Localização";
+"location_selection_searchbar_placeholder" = "Pesquisar";
+"location_selection_search_history_title" = "Recentes";
+
+/* Buttons */
+"location_selection_select_button_title" = "Selecionar";
+
+/* Alert Views */
+"location_selection_no_internet_error_title" = "Erro";
+"location_selection_no_internet_error_message" = "Parece não haver conexão com a Internet";
+
+
+/* MARK: - Other Alert Views */
+"alert_selected_period_changed_title" = "%@ selecionado";
+"alert_selected_period_changed_message" = "Desde que um %@ foi iniciado, o período atual foi ajustado automaticamente.\n\nPara alternar entre períodos e visualizar transações anteriores, basta clicar no botão \"%@\" no canto superior esquerdo da tela e selecionar o período de tempo desejado.";
+"alert_selected_period_changed_new_month" = "novo mês";
+"alert_selected_period_changed_new_year" = "novo ano";
+
+"alert_no_mail_initialized_title" = "Nenhuma conta de e-mail";
+"alert_no_mail_initialized_message" = "Parece que você não tem uma conta de e-mail configurada no seu dispositivo. No entanto, isso é obrigatório para usar esse recurso.";
+
+"alert_no_camera_title" = "Nenhuma câmera disponível";
+"alert_no_camera_message" = "Parece que você não tem uma câmera. No entanto, é obrigatório utilizar este recurso.";
+
+"alert_permissions_title" = "Quase lá!";
+"alert_permissions_activate_button" = "Ativar agora";
+"alert_permissions_cancel_button" = "Talvez mais tarde";
+
+"alert_camera_permissions_message" = "Para tirar fotos, tudo o que você precisa fazer é ativar o acesso à \"câmera\" nas configurações.";
+"alert_photolibrary_permissions_message" = "Para adicionar fotos, tudo o que você precisa fazer é ativar o acesso a \"fotos\" nas configurações.";
+"alert_notifications_permissions_message" = "Para receber notificações push, tudo o que você precisa fazer é ativar \"notificações\" nas configurações.";
+
+
+/* MARK: - Tips */
+"period_selection_tip_title" = "Alterar período";
+"period_selection_tip_message" = "Clique aqui para alterar o período exibido. Isso afeta todas as visualizações (visão geral, transações e orçamentos).";
+"interactive_charts_tip_title" = "Gráficos interativos";
+"interactive_charts_tip_message" = "Deslize para a esquerda ou para a direita para alterar o gráfico ativo ou pressione longamente um gráfico para visualizar os valores de uma data específica.";
+"switch_budget_books_tip_title" = "Mudar de Caderno de Orçamento";
+"switch_budget_books_tip_message" = "Pressione longamente a guia de visão geral para alternar rapidamente entre seus Cadernos de Orçamento.";
+
+
+/* MARK: - Watch App */
+/* Titles */
+"cloud_sync_status_section_title" = "Status de sincronização do iCloud";
+"cloud_sync_status_footer_title" = "Nota: Você precisa estar conectado ao iCloud para sincronizar dados do seu iPhone.";
+
+
+/* MARK: - Localized URLs */
+"imprintUrl" = "";
+"termsOfUseUrl" = "";
+"privacyUrl" = "";
+"privacyUrlWeb" = "";
+"imprintUrlWeb" = "";
+"familySharingUrl" = "";
+
+
+/* MARK: - Default Data */
+"default_account_name" = "Conta padrão";
+
+"default_category_group_name_income" = "Receita";
+"default_category_name_salary" = "Salário";
+
+"default_category_group_name_free_time" = "Lazer";
+"default_category_name_shopping" = "Compras";
+"default_category_name_vacation" = "Férias";
+
+"default_category_group_name_mobility" = "Mobilidade";
+"default_category_name_car" = "Carro";
+
+"default_category_group_name_groceries" = "Mercado";
+"default_category_name_supermarket" = "Supermercado";
+"default_category_name_restaurant" = "Restaurante";
+"default_category_name_fast_food" = "Fast Food";
+
+"default_category_group_name_living" = "Moradia";
+"default_category_name_rent" = "Aluguel";
+
+"default_category_group_name_miscellaneous" = "Diversos";
+
+"default_reminder_title" = "Registrar despesas";
+
+
+/* MARK: - Color Sections */
+"color_section_classic_title" = "Clássico";
+"color_section_sunset_title" = "Pôr do Sol";
+"color_section_afterglow_title" = "Brilho Posterior";
+"color_section_ocean_title" = "Oceano";
+"color_section_nightsky_title" = "Céu Noturno";
+"color_section_apple_title" = "Apple Inc.";
+"color_section_pastel_title" = "Pastel";
+
+
+/* MARK: - Color Keywords */
+"color_keyword_custom" = "Personalizado";
+"color_keyword_red" = "Vermelho";
+"color_keyword_green" = "Verde";
+"color_keyword_blue" = "Azul";
+"color_keyword_yellow" = "Amarelo";
+"color_keyword_orange" = "Laranja";
+"color_keyword_purple" = "Roxo";
+"color_keyword_pink" = "Rosa";
+"color_keyword_brown" = "Marrom";
+"color_keyword_mint" = "Menta";
+"color_keyword_cyan" = "Ciano";
+"color_keyword_violet" = "Violeta";
+"color_keyword_gray" = "Cinza";
+
+
+/* MARK: - Icon Sections */
+"icon_section_suggestions_title" = "Sugestões";
+"icon_section_general_title" = "Geral";
+"icon_section_mobility_title" = "Mobilidade";
+"icon_section_household_title" = "Casa";
+"icon_section_freetime_title" = "Lazer";
+"icon_section_nature_title" = "Natureza";
+"icon_section_food_and_drinks_title" = "Comida e Bebida";
+"icon_section_shopping_title" = "Compras";
+"icon_section_health_title" = "Saúde";
+"icon_section_office_title" = "Escritório";
+"icon_section_arrows_title" = "Setas";
+"icon_section_objects_title" = "Objetos";
+"icon_section_people_title" = "Pessoas";
+"icon_section_buildings_title" = "Construções";
+"icon_section_payment_methods_title" = "Formas de Pagamento";
+
+
+/* MARK: - Icon Keywords */
+"icon_keyword_emoji" = "Emoji";
+"icon_keyword_tag" = "Tag";
+"icon_keyword_heart" = "Coração";
+"icon_keyword_star" = "Estrela";
+"icon_keyword_folder" = "Pasta";
+"icon_keyword_bookmark" = "Marcador";
+"icon_keyword_building" = "Construção";
+"icon_keyword_house" = "Casa";
+"icon_keyword_lightbulb" = "Lâmpada";
+"icon_keyword_fan" = "Ventilador";
+"icon_keyword_lamp" = "Abajur";
+"icon_keyword_alarm_system" = "Sistema de alarme";
+"icon_keyword_webcam" = "Webcam";
+"icon_keyword_camera" = "Câmera";
+"icon_keyword_door" = "Porta";
+"icon_keyword_garage" = "Garagem";
+"icon_keyword_window" = "Janela";
+"icon_keyword_blinds" = "Persianas";
+"icon_keyword_roller" = "Rolo";
+"icon_keyword_curtains" = "Cortinas";
+"icon_keyword_air_purifier" = "Purificador de ar";
+"icon_keyword_dehumidifier" = "Desumidificador";
+"icon_keyword_humidifier" = "Umidificador";
+"icon_keyword_heater" = "Aquecedor";
+"icon_keyword_air_conditioner" = "Ar Condicionado";
+"icon_keyword_sprinkler" = "Aspersor";
+"icon_keyword_trash" = "Lixeira";
+"icon_keyword_spigot" = "Torneira";
+"icon_keyword_shower" = "Chuveiro";
+"icon_keyword_bathtub" = "Banheira";
+"icon_keyword_pipe" = "Encanamento";
+"icon_keyword_hifi_reveiver" = "Receptor Hi-Fi";
+"icon_keyword_video_projector" = "Projetor de vídeo";
+"icon_keyword_beamer" = "Projetor";
+"icon_keyword_wifi_router" = "Roteador Wi-Fi";
+"icon_keyword_internet" = "Internet";
+"icon_keyword_party" = "Festa";
+"icon_keyword_balloon" = "Balão";
+"icon_keyword_pan" = "Frigideira";
+"icon_keyword_cooking" = "Cozinhar";
+"icon_keyword_kitchen" = "Cozinha";
+"icon_keyword_popcorn" = "Pipoca";
+"icon_keyword_cinema" = "Cinema";
+"icon_keyword_movie" = "Filme";
+"icon_keyword_food" = "Comida";
+"icon_keyword_bed" = "Cama";
+"icon_keyword_bedroom" = "Quarto";
+"icon_keyword_hotel" = "Hotel";
+"icon_keyword_sofa" = "Sofá";
+"icon_keyword_couch" = "Sofá";
+"icon_keyword_livingroom" = "Sala de Estar";
+"icon_keyword_chair" = "Cadeira";
+"icon_keyword_armchair" = "Poltrona";
+"icon_keyword_cabinet" = "Armário";
+"icon_keyword_fireplace" = "Lareira";
+"icon_keyword_washer" = "Lavadora";
+"icon_keyword_dryer" = "Secadora";
+"icon_keyword_dishwasher" = "Lava-louças";
+"icon_keyword_oven" = "Forno";
+"icon_keyword_stove" = "Fogão";
+"icon_keyword_microwave" = "Micro-ondas";
+"icon_keyword_refrigerator" = "Geladeira";
+"icon_keyword_sink" = "Pia";
+"icon_keyword_toilet" = "Vaso sanitário";
+"icon_keyword_bathroom" = "Banheiro";
+"icon_keyword_tv_remote" = "Controle Remoto";
+"icon_keyword_tv" = "TV";
+"icon_keyword_person" = "Pessoa";
+"icon_keyword_human" = "Humano";
+"icon_keyword_airplane" = "Avião";
+"icon_keyword_vacation" = "Férias";
+"icon_keyword_car" = "Carro";
+"icon_keyword_electric_car" = "Carro Elétrico";
+"icon_keyword_charging_station" = "Estação de carregamento";
+"icon_keyword_car_pool" = "Carona";
+"icon_keyword_bus" = "Ônibus";
+"icon_keyword_tram" = "Bonde";
+"icon_keyword_railroad" = "Ferrovia";
+"icon_keyword_cablecar" = "Teleférico";
+"icon_keyword_ferry" = "Balsa";
+"icon_keyword_ship" = "Navio";
+"icon_keyword_truck" = "Caminhão";
+"icon_keyword_relocation" = "Mudança";
+"icon_keyword_bicycle" = "Bicicleta";
+"icon_keyword_sport" = "Esporte";
+"icon_keyword_scooter" = "Scooter";
+"icon_keyword_sailboat" = "Veleiro";
+"icon_keyword_fuel" = "Combustível";
+"icon_keyword_refuel" = "Reabastecer";
+"icon_keyword_gas_station" = "Posto de Gasolina";
+"icon_keyword_walking" = "Caminhada";
+"icon_keyword_running" = "Corrida";
+"icon_keyword_rugby" = "Rugby";
+"icon_keyword_badminton" = "Badminton";
+"icon_keyword_tennis" = "Tênis";
+"icon_keyword_dancing" = "Dança";
+"icon_keyword_skiing" = "Esqui";
+"icon_keyword_swimming" = "Natação";
+"icon_keyword_skating" = "Patinação";
+"icon_keyword_strengthtraining" = "Musculação";
+"icon_keyword_gym" = "Academia";
+"icon_keyword_yoga" = "Yoga";
+"icon_keyword_bowling" = "Boliche";
+"icon_keyword_sportscourt" = "Quadra esportiva";
+"icon_keyword_stadium" = "Estádio";
+"icon_keyword_soccer" = "Futebol";
+"icon_keyword_golf" = "Golfe";
+"icon_keyword_baseball" = "Beisebol";
+"icon_keyword_basketball" = "Basquete";
+"icon_keyword_volleyball" = "Vôlei";
+"icon_keyword_trophy" = "Troféu";
+"icon_keyword_medal" = "Medalha";
+"icon_keyword_flag" = "Bandeira";
+"icon_keyword_race" = "Corrida";
+"icon_keyword_gamecontroller" = "Controle de videogame";
+"icon_keyword_videogames" = "Videogames";
+"icon_keyword_gaming" = "Jogos";
+"icon_keyword_playstation" = "PlayStation";
+"icon_keyword_xbox" = "Xbox";
+"icon_keyword_nintento_switch" = "Nintendo Switch";
+"icon_keyword_book" = "Livro";
+"icon_keyword_books" = "Livros";
+"icon_keyword_magazine" = "Revista";
+"icon_keyword_reading" = "Leitura";
+"icon_keyword_painting" = "Pintura";
+"icon_keyword_drawing" = "Desenho";
+"icon_keyword_theater" = "Teatro";
+"icon_keyword_singing" = "Canto";
+"icon_keyword_karaoke" = "Karaokê";
+"icon_keyword_music" = "Música";
+"icon_keyword_spotify" = "Spotify";
+"icon_keyword_apple_music" = "Apple Music";
+"icon_keyword_piano" = "Piano";
+"icon_keyword_guitar" = "Violão";
+"icon_keyword_rockband" = "Banda de Rock";
+"icon_keyword_festival" = "Festival";
+"icon_keyword_tent" = "Barraca";
+"icon_keyword_dice" = "Dados";
+"icon_keyword_boardgames" = "Jogos de Tabuleiro";
+"icon_keyword_gambling" = "Apostas";
+"icon_keyword_photography" = "Fotografia";
+"icon_keyword_photo" = "Foto";
+"icon_keyword_world" = "Mundo";
+"icon_keyword_globe" = "Globo";
+"icon_keyword_sun" = "Sol";
+"icon_keyword_summer" = "Verão";
+"icon_keyword_moon" = "Lua";
+"icon_keyword_stars" = "Estrelas";
+"icon_keyword_cloud" = "Nuvem";
+"icon_keyword_icloud" = "iCloud";
+"icon_keyword_rain" = "Chuva";
+"icon_keyword_flame" = "Chama";
+"icon_keyword_fire" = "Fogo";
+"icon_keyword_snow" = "Neve";
+"icon_keyword_winter" = "Inverno";
+"icon_keyword_bolt" = "Raio";
+"icon_keyword_plug" = "Tomada";
+"icon_keyword_electric" = "Elétrico";
+"icon_keyword_electrics" = "Elétricos";
+"icon_keyword_electricity" = "Eletricidade";
+"icon_keyword_tornado" = "Tornado";
+"icon_keyword_sea" = "Mar";
+"icon_keyword_hare" = "Lebre";
+"icon_keyword_rabbit" = "Coelho";
+"icon_keyword_animal" = "Animal";
+"icon_keyword_tortoise" = "Tartaruga";
+"icon_keyword_lizard" = "Lagarto";
+"icon_keyword_bird" = "Pássaro";
+"icon_keyword_ant" = "Formiga";
+"icon_keyword_ladybug" = "Joaninha";
+"icon_keyword_fish" = "Peixe";
+"icon_keyword_pet" = "Animal de estimação";
+"icon_keyword_cat" = "Gato";
+"icon_keyword_dog" = "Cachorro";
+"icon_keyword_leaf" = "Folha";
+"icon_keyword_plant" = "Planta";
+"icon_keyword_flower" = "Flor";
+"icon_keyword_eating" = "Comer";
+"icon_keyword_restaurant" = "Restaurante";
+"icon_keyword_drinking" = "Beber";
+"icon_keyword_cafe" = "Cafeteria";
+"icon_keyword_coffee" = "Café";
+"icon_keyword_fastfood" = "Fast food";
+"icon_keyword_picnic" = "Piquenique";
+"icon_keyword_wine" = "Vinho";
+"icon_keyword_birthday" = "Aniversário";
+"icon_keyword_cake" = "Bolo";
+"icon_keyword_carrot" = "Cenoura";
+"icon_keyword_vegetables" = "Legumes";
+"icon_keyword_bag" = "Sacola";
+"icon_keyword_cone" = "Cone";
+"icon_keyword_shopping" = "Compras";
+"icon_keyword_supermarket" = "Supermercado";
+"icon_keyword_groceries" = "Mantimentos";
+"icon_keyword_creditcard" = "Cartão de Crédito";
+"icon_keyword_giftcard" = "Vale-presente";
+"icon_keyword_gift" = "Presente";
+"icon_keyword_clothes" = "Roupas";
+"icon_keyword_clothing" = "Vestuário";
+"icon_keyword_online" = "Online";
+"icon_keyword_amazon" = "Amazon";
+"icon_keyword_package" = "Pacote";
+"icon_keyword_apple" = "Maçã";
+"icon_keyword_banknote" = "Cédula";
+"icon_keyword_refund" = "Reembolso";
+"icon_keyword_dollar" = "Dólar";
+"icon_keyword_cents" = "Centavos";
+"icon_keyword_yen" = "Iene";
+"icon_keyword_pound" = "Libra";
+"icon_keyword_franc" = "Franco";
+"icon_keyword_lira" = "Lira";
+"icon_keyword_ruble" = "Rublo";
+"icon_keyword_euro" = "Euro";
+"icon_keyword_rupee" = "Rúpia";
+"icon_keyword_peso" = "Peso";
+"icon_keyword_bitcoin" = "Bitcoin";
+"icon_keyword_real" = "Real";
+"icon_keyword_case" = "Mala";
+"icon_keyword_lungs" = "Pulmões";
+"icon_keyword_allergens" = "Alérgenos";
+"icon_keyword_thermometer" = "Termômetro";
+"icon_keyword_bandage" = "Curativo";
+"icon_keyword_syringe" = "Seringa";
+"icon_keyword_medicine" = "Remédio";
+"icon_keyword_drug" = "Medicamento";
+"icon_keyword_facemask" = "Máscara facial";
+"icon_keyword_pills" = "Comprimidos";
+"icon_keyword_cross" = "Cruz";
+"icon_keyword_hospital" = "Hospital";
+"icon_keyword_ivfluid" = "Soro";
+"icon_keyword_eye" = "Olho";
+"icon_keyword_brain" = "Cérebro";
+"icon_keyword_ear" = "Ouvido";
+"icon_keyword_mouth" = "Boca";
+"icon_keyword_ecg" = "ECG";
+"icon_keyword_shield" = "Escudo";
+"icon_keyword_insurance" = "Seguro";
+"icon_keyword_video_conference" = "Videoconferência";
+"icon_keyword_facetime" = "Facetime";
+"icon_keyword_phone" = "Telefone";
+"icon_keyword_mobilephone" = "Celular";
+"icon_keyword_iphone" = "iPhone";
+"icon_keyword_tablet" = "Tablet";
+"icon_keyword_ipad" = "iPad";
+"icon_keyword_macintosh" = "Macintosh";
+"icon_keyword_macbook" = "Macbook";
+"icon_keyword_imac" = "iMac";
+"icon_keyword_smartphone" = "Smartphone";
+"icon_keyword_calling" = "Ligando";
+"icon_keyword_message" = "Mensagem";
+"icon_keyword_envelope" = "Envelope";
+"icon_keyword_mail" = "Correio";
+"icon_keyword_email" = "E-mail";
+"icon_keyword_chart" = "Gráfico";
+"icon_keyword_stocks" = "Ações";
+"icon_keyword_investment" = "Investimento";
+"icon_keyword_signature" = "Assinatura";
+"icon_keyword_contract" = "Contrato";
+"icon_keyword_computer" = "Computador";
+"icon_keyword_pc" = "PC";
+"icon_keyword_display" = "Monitor";
+"icon_keyword_mouse" = "Mouse";
+"icon_keyword_keyboard" = "Teclado";
+"icon_keyword_printer" = "Impressora";
+"icon_keyword_scanner" = "Scanner";
+"icon_keyword_pin" = "Alfinete";
+"icon_keyword_paperclip" = "Clipe de papel";
+"icon_keyword_clipboard" = "Prancheta";
+"icon_keyword_list" = "Lista";
+"icon_keyword_server" = "Servidor";
+"icon_keyword_simcard" = "Chip";
+"icon_keyword_bank" = "Banco";
+"icon_keyword_apple_watch" = "Apple Watch";
+"icon_keyword_clock" = "Relógio";
+"icon_keyword_alarm" = "Alarme";
+"icon_keyword_box" = "Caixa";
+"icon_keyword_wand" = "Varinha mágica";
+"icon_keyword_hourglass" = "Ampulheta";
+"icon_keyword_newspaper" = "Jornal";
+"icon_keyword_wrench" = "Chave";
+"icon_keyword_screwdriver" = "Chave de fenda";
+"icon_keyword_hammer" = "Martelo";
+"icon_keyword_craftsman" = "Artesão";
+"icon_keyword_tools" = "Ferramentas";
+"icon_keyword_plumber" = "Encanador";
+"icon_keyword_construction_market" = "Loja de material de construção";
+"icon_keyword_scissors" = "Tesoura";
+"icon_keyword_hairdresser" = "Cabeleireiro";
+"icon_keyword_key" = "Chave";
+"icon_keyword_school" = "Escola";
+"icon_keyword_university" = "Universidade";
+"icon_keyword_study" = "Estudo";
+"icon_keyword_tuition_fees" = "Mensalidades";
+"icon_keyword_flashlight" = "Lanterna";
+"icon_keyword_bell" = "Sino";
+"icon_keyword_subscription" = "Assinatura";
+"icon_keyword_loupe" = "Lupa";
+"icon_keyword_binoculars" = "Binóculos";
+"icon_keyword_rosette" = "Roseta";
+"icon_keyword_crown" = "Coroa";
+"icon_keyword_umbrella" = "Guarda-chuva";
+"icon_keyword_beach" = "Praia";
+"icon_keyword_megaphone" = "Megafone";
+"icon_keyword_advertisement" = "Publicidade";
+"icon_keyword_puzzle" = "Quebra-cabeça";
+"icon_keyword_lab" = "Laboratório";
+"icon_keyword_calendar" = "Calendário";
+"icon_keyword_rent" = "Aluguel";
+"icon_keyword_flat" = "Apartamento";
+"icon_keyword_work" = "Trabalho";
+"icon_keyword_salary" = "Salário";
+"icon_keyword_corona" = "Corona";
+"icon_keyword_rainbow" = "Arco-íris";
+"icon_keyword_glasses" = "Óculos";
+"icon_keyword_sunglasses" = "Óculos de sol";
+"icon_keyword_discount" = "Desconto";
+"icon_keyword_percent" = "Porcentagem";
+"icon_keyword_wallet" = "Carteira";
+"icon_keyword_convertible" = "Conversível";
+"icon_keyword_drone" = "Drone";
+"icon_keyword_motorcycle" = "Motocicleta";
+"icon_keyword_tire" = "Pneu";
+"icon_keyword_oilcan" = "Lata de óleo";
+"icon_keyword_keys" = "Chaves";
+"icon_keyword_fire_extintor" = "Extintor de incêndio";
+"icon_keyword_hockey" = "Hóquei";
+"icon_keyword_ice_hockey" = "Hóquei no Gelo";
+"icon_keyword_ice_skating" = "Patinação no Gelo";
+"icon_keyword_rowing" = "Remo";
+"icon_keyword_inhaler" = "Inalador";
+"icon_keyword_wheelchair" = "Cadeira de rodas";
+"icon_keyword_vacuum" = "Aspirador de pó";
+"icon_keyword_doctor" = "Médico";
+"icon_keyword_dentist" = "Dentista";
+"icon_keyword_parking" = "Estacionamento";
+
+
+/* MARK: - App Intents */
+/* Entities */
+"budget_book_entity_name" = "Caderno de Orçamento";
+"account_entity_name" = "Conta";
+"category_group_entity_name" = "Pasta";
+"category_entity_name" = "Categoria";
+"payee_entity_name" = "Beneficiário";
+
+/* Categories */
+"add_category_name" = "Adicionar";
+"open_category_name" = "Abrir";
+"show_category_name" = "Mostrar";
+"search_category_name" = "Pesquisar";
+
+/* Search */
+"search_budget_book_title" = "Pesquisar Caderno de Orçamento";
+"search_budget_book_description" = "Pesquisar um Caderno de Orçamento específico por nome";
+"search_budget_book_parameter_summary" = "Pesquisar Caderno de Orçamento com ${name}";
+"search_account_title" = "Pesquisar conta";
+"search_account_description" = "Pesquisar uma conta específica por nome";
+"search_account_parameter_summary" = "Pesquisar conta com ${name} em ${budgetBook}";
+"search_category_group_title" = "Pesquisar pasta";
+"search_category_group_description" = "Pesquisar uma pasta específica por nome";
+"search_category_group_parameter_summary" = "Pesquisar pasta com ${name} em ${budgetBook}";
+"search_category_title" = "Pesquisar categoria";
+"search_category_description" = "Pesquisar uma categoria específica por nome";
+"search_category_parameter_summary" = "Pesquisar categoria com ${name} em ${categoryGroup} de ${budgetBook}";
+"search_payee_title" = "Pesquisar beneficiário";
+"search_payee_description" = "Pesquisar um beneficiário específico por nome";
+"search_payee_parameter_summary" = "Pesquisar beneficiário com ${name} em ${budgetBook}";
+
+"name_parameter_title" = "Nome";
+"name_parameter_dialog" = "Qual é o nome?";
+
+"budget_book_parameter_title" = "Caderno de Orçamento";
+"budget_book_parameter_description" = "O Caderno de Orçamento associado.";
+"budget_book_parameter_dialog" = "Qual é o Caderno de Orçamento associado?";
+"category_group_parameter_title" = "Pasta";
+"category_group_parameter_description" = "A pasta associada.";
+"category_group_parameter_dialog" = "Qual é a pasta associada?";
+
+/* Open */
+"open_add_new_income_view_title" = "Adicionar nova receita";
+"open_add_new_income_view_description" = "Abre a nova visualização de receita dentro do aplicativo.";
+"open_add_new_expense_view_title" = "Adicionar nova despesa";
+"open_add_new_expense_view_description" = "Abre a visualização adicionar nova despesa dentro do aplicativo.";
+"open_add_new_transfer_view_title" = "Adicionar nova transferência";
+"open_add_new_transfer_view_description" = "Abre a nova visualização de transferência dentro do aplicativo.";
+"open_add_new_recurring_view_title" = "Adicionar nova transação recorrente";
+"open_add_new_recurring_view_description" = "Abre a nova visualização de transação recorrente no aplicativo.";
+"open_upcoming_transactions_view_title" = "Transações planejadas";
+"open_upcoming_transactions_view_description" = "Abre a visualização de transações planejadas dentro do aplicativo.";
+
+/* Show */
+"show_chart_title" = "Mostrar gráfico";
+"show_chart_description" = "Exibe um gráfico dos saldos da sua conta, receitas ou despesas para o período especificado.";
+"show_chart_parameter_summary" = "Mostrar gráfico ${type} para ${periodType}";
+
+"chart_type_parameter_title" = "Tipo";
+"chart_type_dialog" = "Que tipo de gráfico você quer?";
+"chart_type_account_balances_title" = "Saldos de Contas";
+"chart_type_balance_title" = "Saldo";
+"chart_type_total_income_title" = "Receita total";
+"chart_type_total_expenses_title" = "Despesa total";
+"chart_type_fixed_expenses_title" = "Despesas fixas";
+"chart_type_variable_expenses_title" = "Despesas variáveis";
+
+"chart_period_type_parameter_title" = "Período";
+"chart_period_type_dialog" = "Qual período você quer ver?";
+"chart_type_current_month_title" = "Mês atual";
+"chart_type_current_year_title" = "Ano atual";
+
+
+/* MARK: - Dummy Data */
+"default_budget_book_name" = "Meu Caderno de Orçamento";
+"default_credit_card_name" = "Cartão de crédito";
+"default_location_address" = "Fürstenberg";

--- a/pt-BR/Localizable.stringsdict
+++ b/pt-BR/Localizable.stringsdict
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>minute</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>minuto</string>
+			<key>other</key>
+			<string>minutos</string>
+		</dict>
+	</dict>
+	<key>hour</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>hora</string>
+			<key>other</key>
+			<string>horas</string>
+		</dict>
+	</dict>
+	<key>day</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>dia</string>
+			<key>other</key>
+			<string>dias</string>
+		</dict>
+	</dict>
+	<key>week</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>semana</string>
+			<key>other</key>
+			<string>semanas</string>
+		</dict>
+	</dict>
+	<key>month</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>mês</string>
+			<key>other</key>
+			<string>meses</string>
+		</dict>
+	</dict>
+	<key>year</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>ano</string>
+			<key>other</key>
+			<string>anos</string>
+		</dict>
+	</dict>
+	<key>number_of_transactions</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d transação</string>
+			<key>other</key>
+			<string>%1$d transações</string>
+		</dict>
+	</dict>
+	<key>number_of_upcoming_transactions</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d transação planejada</string>
+			<key>other</key>
+			<string>%1$d transações planejadas</string>
+		</dict>
+	</dict>
+	<key>number_of_reminded_transactions</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d transação com lembrete</string>
+			<key>other</key>
+			<string>%1$d transações com lembrete</string>
+		</dict>
+	</dict>
+	<key>number_of_budgets</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d orçamento</string>
+			<key>other</key>
+			<string>%1$d orçamentos</string>
+		</dict>
+	</dict>
+	<key>number_of_categories</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d categoria</string>
+			<key>other</key>
+			<string>%1$d categorias</string>
+		</dict>
+	</dict>
+	<key>number_of_attachments</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d anexo</string>
+			<key>other</key>
+			<string>%1$d anexos</string>
+		</dict>
+	</dict>
+	<key>repeats_every_day</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete todos os dias.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d dias.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_week_on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete semanalmente na %2$@.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d semanas na %2$@.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_month</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete mensalmente.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d meses.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_month_on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete mensalmente no %2$@.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d meses no %2$@.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_month_on_the</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete mensalmente no %2$@ %3$@.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d meses no %2$@ %3$@.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_year_in</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete anualmente em %2$@.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d anos em %2$@.</string>
+		</dict>
+	</dict>
+	<key>repeats_every_year_on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@value@</string>
+		<key>value</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Repete anualmente no %2$@ %3$@ de %4$@.</string>
+			<key>other</key>
+			<string>Repete a cada %1$d anos no %2$@ %3$@ de %4$@.</string>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds translation files to pt-BR. 

Gemini 2.5 Pro did the rough strokes and I proofread/corrected a fine pass which took a while given the sheer size of the file. After a few tweaks though I’m happy with the result. Feels a lot more natural for Brazilians.

On a related note, I noticed the pt-PT translation (which I used as the base initially) is slightly mixed up with pt-BR, Spanish and English. Also, some translations are just incorrect (e.g. “Archive account” has been translated to “Accounts of archive”, etc). I don’t know enough of pt-PT to confidently make or review changes, but just an FYI.